### PR TITLE
Trim back of redundant functionality in FixVMMC class

### DIFF
--- a/src/MC/fix_vmmc.cpp
+++ b/src/MC/fix_vmmc.cpp
@@ -20,6 +20,7 @@
 
 #include "fix_vmmc.h"
 #include "VMMC.h"
+#include "MersenneTwister.h"
 
 #include "angle.h"
 #include "atom.h"
@@ -64,8 +65,7 @@ static constexpr double MAXENERGYSIGNAL = 1.0e100;
 
 static constexpr double MAXENERGYTEST = 1.0e50;
 
-enum { EXCHATOM, EXCHMOL };          // exchmode
-enum { NONE, MOVEATOM, MOVEMOL };    // movemode
+enum { NONE, MOVEATOM };    // movemode
 
 /* ---------------------------------------------------------------------- */
 
@@ -74,7 +74,7 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
     groupstrings(nullptr), grouptypestrings(nullptr), grouptypebits(nullptr), grouptypes(nullptr),
     local_gas_list(nullptr), random_equal(nullptr), random_unequal(nullptr)
 {
-  if (narg < 11) utils::missing_cmd_args(FLERR, "fix vmmc", error);
+  if (narg < 9) utils::missing_cmd_args(FLERR, "fix vmmc", error);
 
   if (atom->molecular == Atom::TEMPLATE)
     error->all(FLERR,"Fix vmmc does not (yet) work with atom_style template");
@@ -95,16 +95,13 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
   // required args
 
   nevery = utils::inumeric(FLERR, arg[3], false, lmp);
-  nexchanges = utils::inumeric(FLERR, arg[4], false, lmp);
-  nmcmoves = utils::inumeric(FLERR, arg[5], false, lmp);
-  nvmmc_type = utils::expand_type_int(FLERR, arg[6], Atom::ATOM, lmp);
-  seed = utils::inumeric(FLERR, arg[7], false, lmp);
-  reservoir_temperature = utils::numeric(FLERR, arg[8], false, lmp);
-  chemical_potential = utils::numeric(FLERR, arg[9], false, lmp);
-  displace = utils::numeric(FLERR, arg[10], false, lmp);
+  nmcmoves = utils::inumeric(FLERR, arg[4], false, lmp);
+  nvmmc_type = utils::expand_type_int(FLERR, arg[5], Atom::ATOM, lmp);
+  seed = utils::inumeric(FLERR, arg[6], false, lmp);
+  reservoir_temperature = utils::numeric(FLERR, arg[7], false, lmp);
+  displace = utils::numeric(FLERR, arg[8], false, lmp);
 
   if (nevery <= 0) error->all(FLERR, "Illegal fix vmmc command");
-  if (nexchanges < 0) error->all(FLERR, "Illegal fix vmmc command");
   if (nmcmoves < 0) error->all(FLERR, "Illegal fix vmmc command");
   if (seed <= 0) error->all(FLERR, "Illegal fix vmmc command");
   if (reservoir_temperature < 0.0)
@@ -113,7 +110,7 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
 
   // read options from end of input line
 
-  options(narg-11,&arg[11]);
+  options(narg-9,&arg[9]);
 
   // random number generator, same for all procs
 
@@ -158,12 +155,9 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
     region_volume = max_region_volume * static_cast<double>(inside) / static_cast<double>(attempts);
   }
 
-  if (charge_flag && atom->q == nullptr)
-    error->all(FLERR,"Fix vmmc atom has charge, but atom style does not");
-
   // compute the number of MC cycles that occur nevery timesteps
 
-  ncycles = nexchanges + nmcmoves;
+  ncycles = nmcmoves;
 
   // set up reneighboring
 
@@ -176,8 +170,6 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
 
   ntranslation_attempts = 0.0;
   ntranslation_successes = 0.0;
-  nrotation_attempts = 0.0;
-  nrotation_successes = 0.0;
 
   vmmc_nmax = 0;
   local_gas_list = nullptr;
@@ -193,23 +185,16 @@ void FixVMMC::options(int narg, char **arg)
 
   // defaults
 
-  exchmode = EXCHATOM;
   movemode = NONE;
   patomtrans = 0.0;
   pmctot = 0.0;
   max_rotation_angle = 10*MY_PI/180;
   region_volume = 0;
   max_region_attempts = 1000;
-  molecule_group = 0;
-  molecule_group_bit = 0;
-  molecule_group_inversebit = 0;
   exclusion_group = 0;
   exclusion_group_bit = 0;
   pressure_flag = false;
   pressure = 0.0;
-  fugacity_coeff = 1.0;
-  charge = 0.0;
-  charge_flag = false;
   full_flag = false;
   ngroups = 0;
   int ngroupsmax = 0;
@@ -252,15 +237,6 @@ void FixVMMC::options(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
       pressure = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       pressure_flag = true;
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"fugacity_coeff") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      fugacity_coeff = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"charge") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      charge = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      charge_flag = true;
       iarg += 2;
     }  else if (strcmp(arg[iarg],"full_energy") == 0) {
       full_flag = true;
@@ -358,16 +334,6 @@ FixVMMC::~FixVMMC()
     }
   }
 
-  if (molecule_group_bit && group) {
-    auto group_id = std::string("FixVMMC:rotation_gas_atoms:") + id;
-    try {
-      group->assign(group_id + " delete");
-    } catch (std::exception &e) {
-      if (comm->me == 0)
-        fprintf(stderr, "Error deleting group %s: %s\n", group_id.c_str(), e.what());
-    }
-  }
-
   if (full_flag && group && neighbor) {
     int igroupall = group->find("all");
     neighbor->exclusion_group_group_delete(exclusion_group,igroupall);
@@ -430,14 +396,11 @@ void FixVMMC::init()
   // set probabilities for MC moves
 
   if (nmcmoves > 0) {
+    movemode = MOVEATOM;
     if (pmctot == 0.0) {
-      if (exchmode == EXCHATOM) {
-        movemode = MOVEATOM;
         patomtrans = 1.0;
-      }
     }
     else {
-      movemode = MOVEATOM;
       patomtrans /= pmctot;
     }
   } else movemode = NONE;
@@ -458,27 +421,6 @@ void FixVMMC::init()
   }
 
   if (full_flag) c_pe = modify->compute[modify->find_compute("thermo_pe")];
-
-  int *type = atom->type;
-
-  if (exchmode == EXCHATOM) {
-    if (nvmmc_type <= 0 || nvmmc_type > atom->ntypes)
-      error->all(FLERR,"Invalid atom type in fix vmmc command");
-  }
-
-  // if atoms are exchanged, warn if any deletable atom has a mol ID
-
-  if ((exchmode == EXCHATOM) && atom->molecule_flag) {
-    tagint *molecule = atom->molecule;
-    int flag = 0;
-    for (int i = 0; i < atom->nlocal; i++)
-      if (type[i] == nvmmc_type)
-        if (molecule[i]) flag = 1;
-    int flagall;
-    MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
-    if (flagall)
-      error->all(FLERR, "Fix vmmc cannot exchange individual atoms belonging to a molecule");
-  }
 
   if (domain->dimension == 2)
     error->all(FLERR,"Cannot use fix vmmc in a 2d simulation");
@@ -504,9 +446,7 @@ void FixVMMC::init()
     neighbor->modify_params(fmt::format("exclude group {} all",group_id));
   }
 
-  // get all of the needed molecule data if exchanging
-  // or moving molecules, otherwise just get the gas mass
-
+  // get the gas mass
   gas_mass = atom->mass[nvmmc_type];
 
   if (gas_mass <= 0.0)
@@ -530,20 +470,8 @@ void FixVMMC::init()
       error->all(FLERR,"Cannot do VMMC on atoms in atom_modify first group");
   }
 
-  // compute beta, lambda, sigma, and the zz factor
-  // For LJ units, lambda=1
+  // compute beta
   beta = 1.0/(force->boltz*reservoir_temperature);
-  if (strcmp(update->unit_style,"lj") == 0)
-    zz = exp(beta*chemical_potential);
-  else {
-    double lambda = sqrt(force->hplanck*force->hplanck/
-                         (2.0*MY_PI*gas_mass*force->mvv2e*
-                        force->boltz*reservoir_temperature));
-    zz = exp(beta*chemical_potential)/(pow(lambda,3.0));
-  }
-
-  sigma = sqrt(force->boltz*reservoir_temperature*tfac_insert/gas_mass/force->mvv2e);
-  if (pressure_flag) zz = pressure*fugacity_coeff*beta/force->nktv2p;
 
   imagezero = ((imageint) IMGMAX << IMG2BITS) |
              ((imageint) IMGMAX << IMGBITS) | IMGMAX;
@@ -581,7 +509,7 @@ void FixVMMC::init()
 }
 
 /* ----------------------------------------------------------------------
-   attempt Monte Carlo translations, rotations, insertions, and deletions
+   attempt Monte Carlo translations
    done before exchange, borders, reneighbor
    so that ghost atoms and neighbor lists will be correct
 ------------------------------------------------------------------------- */
@@ -909,7 +837,7 @@ double FixVMMC::energy_full()
   }
 
   // clear forces so they don't accumulate over multiple
-  // calls within fix vmmc timestep, e.g. for fix shake
+  // calls within fix vmmc timestep
 
   size_t nbytes = sizeof(double) * (atom->nlocal + atom->nghost);
   if (nbytes) memset(&atom->f[0][0],0,3*nbytes);
@@ -978,28 +906,6 @@ tagint FixVMMC::pick_random_gas_molecule()
 }
 
 /* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::toggle_intramolecular(int i)
-{
-  if (atom->avec->bonds_allow)
-    for (int m = 0; m < atom->num_bond[i]; m++)
-      atom->bond_type[i][m] = -atom->bond_type[i][m];
-
-  if (atom->avec->angles_allow)
-    for (int m = 0; m < atom->num_angle[i]; m++)
-      atom->angle_type[i][m] = -atom->angle_type[i][m];
-
-  if (atom->avec->dihedrals_allow)
-    for (int m = 0; m < atom->num_dihedral[i]; m++)
-      atom->dihedral_type[i][m] = -atom->dihedral_type[i][m];
-
-  if (atom->avec->impropers_allow)
-    for (int m = 0; m < atom->num_improper[i]; m++)
-      atom->improper_type[i][m] = -atom->improper_type[i][m];
-}
-
-/* ----------------------------------------------------------------------
    update the list of gas atoms
 ------------------------------------------------------------------------- */
 
@@ -1051,8 +957,6 @@ double FixVMMC::compute_vector(int n)
 {
   if (n == 0) return ntranslation_attempts;
   if (n == 1) return ntranslation_successes;
-  if (n == 6) return nrotation_attempts;
-  if (n == 7) return nrotation_successes;
   return 0.0;
 }
 
@@ -1079,8 +983,6 @@ void FixVMMC::write_restart(FILE *fp)
   list[n++] = ubuf(next_reneighbor).d;
   list[n++] = ntranslation_attempts;
   list[n++] = ntranslation_successes;
-  list[n++] = nrotation_attempts;
-  list[n++] = nrotation_successes;
   list[n++] = ubuf(update->ntimestep).d;
 
   if (comm->me == 0) {
@@ -1109,8 +1011,6 @@ void FixVMMC::restart(char *buf)
 
   ntranslation_attempts  = list[n++];
   ntranslation_successes = list[n++];
-  nrotation_attempts     = list[n++];
-  nrotation_successes    = list[n++];
 
   bigint ntimestep_restart = (bigint) ubuf(list[n++]).i;
   if (ntimestep_restart != update->ntimestep)

--- a/src/MC/fix_vmmc.cpp
+++ b/src/MC/fix_vmmc.cpp
@@ -13,10 +13,13 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Contributing author: Paul Crozier, Aidan Thompson (SNL)
+   Contributing authors:
+    Lester Hedges (Bristol, UK)
+    Ford Cadman, Oliver Henrich (University of Strathclyde, Glasgow)
 ------------------------------------------------------------------------- */
 
 #include "fix_vmmc.h"
+#include "VMMC.h"
 
 #include "angle.h"
 #include "atom.h"
@@ -158,24 +161,6 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
     region_volume = max_region_volume * static_cast<double>(inside) / static_cast<double>(attempts);
   }
 
-  // error check and further setup for exchmode = EXCHMOL
-
-  if (exchmode == EXCHMOL) {
-    if (onemols[imol]->xflag == 0)
-      error->all(FLERR,"Fix vmmc molecule must have coordinates");
-    if (onemols[imol]->typeflag == 0)
-      error->all(FLERR,"Fix vmmc molecule must have atom types");
-    if (nvmmc_type != 0)
-      error->all(FLERR,"Atom type must be zero in fix vmmc mol command");
-    if (onemols[imol]->qflag == 1 && atom->q == nullptr)
-      error->all(FLERR,"Fix vmmc molecule has charges, but atom style does not");
-
-    if (atom->molecular == Atom::TEMPLATE && onemols != atom->avec->onemols)
-      error->all(FLERR,"Fix vmmc molecule template ID must be same "
-                 "as atom_style template ID");
-    onemols[imol]->check_attributes();
-  }
-
   if (charge_flag && atom->q == nullptr)
     error->all(FLERR,"Fix vmmc atom has charge, but atom style does not");
 
@@ -215,10 +200,6 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
   ntranslation_successes = 0.0;
   nrotation_attempts = 0.0;
   nrotation_successes = 0.0;
-  ndeletion_attempts = 0.0;
-  ndeletion_successes = 0.0;
-  ninsertion_attempts = 0.0;
-  ninsertion_successes = 0.0;
 
   vmmc_nmax = 0;
   local_gas_list = nullptr;
@@ -273,19 +254,7 @@ void FixVMMC::options(int narg, char **arg)
 
   int iarg = 0;
   while (iarg < narg) {
-  if (strcmp(arg[iarg],"mol") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      imol = atom->find_molecule(arg[iarg+1]);
-      if (imol == -1)
-        error->all(FLERR,"Molecule template ID for fix vmmc does not exist");
-      if (atom->molecules[imol]->nset > 1 && comm->me == 0)
-        error->warning(FLERR,"Molecule template for "
-                       "fix vmmc has multiple molecules");
-      exchmode = EXCHMOL;
-      onemols = atom->molecules;
-      nmol = onemols[imol]->nset;
-      iarg += 2;
-  } else if (strcmp(arg[iarg],"mcmoves") == 0) {
+    if (strcmp(arg[iarg],"mcmoves") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal fix vmmc command");
       patomtrans = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       pmoltrans = utils::numeric(FLERR,arg[iarg+2],false,lmp);
@@ -568,26 +537,6 @@ void FixVMMC::init()
       error->all(FLERR, "Fix vmmc cannot exchange individual atoms belonging to a molecule");
   }
 
-  // if molecules are exchanged or moved, check for unset mol IDs
-
-  if (exchmode == EXCHMOL || movemode == MOVEMOL) {
-    tagint *molecule = atom->molecule;
-    int *mask = atom->mask;
-    int flag = 0;
-    for (int i = 0; i < atom->nlocal; i++)
-      if (mask[i] == groupbit)
-        if (molecule[i] == 0) flag = 1;
-    int flagall;
-    MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
-    if (flagall)
-      error->all(FLERR, "All mol IDs should be set for fix vmmc group atoms");
-  }
-
-  if (exchmode == EXCHMOL || movemode == MOVEMOL)
-    if (atom->molecule_flag == 0 || !atom->tag_enable
-        || (atom->map_style == Atom::MAP_NONE))
-      error->all(FLERR, "Fix vmmc molecule command requires that atoms have molecule attributes");
-
   // if rigidflag defined, check for rigid/small fix
   // its molecule template must be same as this one
 
@@ -636,39 +585,10 @@ void FixVMMC::init()
     neighbor->modify_params(fmt::format("exclude group {} all",group_id));
   }
 
-  // create a new group for temporary use with selected molecules
-
-  if (exchmode == EXCHMOL || movemode == MOVEMOL) {
-
-    // create unique group name for atoms to be rotated
-
-    auto group_id = std::string("FixVMMC:rotation_gas_atoms:") + id;
-    group->assign(group_id + " molecule -1");
-    molecule_group = group->find(group_id);
-    if (molecule_group == -1)
-      error->all(FLERR,"Could not find fix vmmc rotation group ID");
-    molecule_group_bit = group->bitmask[molecule_group];
-    molecule_group_inversebit = molecule_group_bit ^ ~0;
-  }
-
   // get all of the needed molecule data if exchanging
   // or moving molecules, otherwise just get the gas mass
 
-  if (exchmode == EXCHMOL || movemode == MOVEMOL) {
-
-    onemols[imol]->compute_mass();
-    onemols[imol]->compute_com();
-    gas_mass = onemols[imol]->masstotal;
-    for (int i = 0; i < onemols[imol]->natoms; i++) {
-      onemols[imol]->x[i][0] -= onemols[imol]->com[0];
-      onemols[imol]->x[i][1] -= onemols[imol]->com[1];
-      onemols[imol]->x[i][2] -= onemols[imol]->com[2];
-    }
-    onemols[imol]->com[0] = 0;
-    onemols[imol]->com[1] = 0;
-    onemols[imol]->com[2] = 0;
-
-  } else gas_mass = atom->mass[nvmmc_type];
+  gas_mass = atom->mass[nvmmc_type];
 
   if (gas_mass <= 0.0)
     error->all(FLERR,"Illegal fix vmmc gas mass <= 0");
@@ -688,7 +608,7 @@ void FixVMMC::init()
     MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
 
     if (flagall)
-      error->all(FLERR,"Cannot do GCMC on atoms in atom_modify first group");
+      error->all(FLERR,"Cannot do VMMC on atoms in atom_modify first group");
   }
 
   // compute beta, lambda, sigma, and the zz factor
@@ -801,15 +721,7 @@ void FixVMMC::pre_exchange()
         if (xmcmove < patomtrans) attempt_atomic_translation_full();
         else if (xmcmove < patomtrans+pmoltrans) attempt_molecule_translation_full();
         else attempt_molecule_rotation_full();
-      } else {
-        double xvmmc = random_equal->uniform();
-        if (exchmode == EXCHATOM) {
-          if (xvmmc < 0.5) attempt_atomic_deletion_full();
-          else attempt_atomic_insertion_full();
-        } else {
-          if (xvmmc < 0.5) attempt_molecule_deletion_full();
-          else attempt_molecule_insertion_full();
-        }
+
       }
     }
     if (triclinic) domain->x2lamda(atom->nlocal);
@@ -828,15 +740,6 @@ void FixVMMC::pre_exchange()
         if (xmcmove < patomtrans) attempt_atomic_translation();
         else if (xmcmove < patomtrans+pmoltrans) attempt_molecule_translation();
         else attempt_molecule_rotation();
-      } else {
-        double xvmmc = random_equal->uniform();
-        if (exchmode == EXCHATOM) {
-          if (xvmmc < 0.5) attempt_atomic_deletion();
-          else attempt_atomic_insertion();
-        } else {
-          if (xvmmc < 0.5) attempt_molecule_deletion();
-          else attempt_molecule_insertion();
-        }
       }
     }
   }
@@ -917,158 +820,6 @@ void FixVMMC::attempt_atomic_translation()
     if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
     update_gas_atoms_list();
     ntranslation_successes += 1.0;
-  }
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_atomic_deletion()
-{
-  ndeletion_attempts += 1.0;
-
-  if (ngas == 0 || ngas <= min_ngas) return;
-
-  int i = pick_random_gas_atom();
-
-  int success = 0;
-  if (i >= 0) {
-    double deletion_energy = energy(i,nvmmc_type,-1,atom->x[i]);
-    if (random_unequal->uniform() <
-        ngas*exp(beta*deletion_energy)/(zz*volume)) {
-      atom->avec->copy(atom->nlocal-1,i,1);
-      atom->nlocal--;
-      success = 1;
-    }
-  }
-
-  int success_all = 0;
-  MPI_Allreduce(&success,&success_all,1,MPI_INT,MPI_MAX,world);
-
-  if (success_all) {
-    atom->natoms--;
-    if (atom->tag_enable) {
-      if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-    }
-    atom->nghost = 0;
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-    update_gas_atoms_list();
-    ndeletion_successes += 1.0;
-  }
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_atomic_insertion()
-{
-  double lamda[3];
-
-  ninsertion_attempts += 1.0;
-
-  if (ngas >= max_ngas) return;
-
-  // pick coordinates for insertion point
-
-  double coord[3];
-  if (region) {
-    int region_attempt = 0;
-    coord[0] = region_xlo + random_equal->uniform() * (region_xhi-region_xlo);
-    coord[1] = region_ylo + random_equal->uniform() * (region_yhi-region_ylo);
-    coord[2] = region_zlo + random_equal->uniform() * (region_zhi-region_zlo);
-    while (region->match(coord[0],coord[1],coord[2]) == 0) {
-      coord[0] = region_xlo + random_equal->uniform() * (region_xhi-region_xlo);
-      coord[1] = region_ylo + random_equal->uniform() * (region_yhi-region_ylo);
-      coord[2] = region_zlo + random_equal->uniform() * (region_zhi-region_zlo);
-      region_attempt++;
-      if (region_attempt >= max_region_attempts) return;
-    }
-    if (triclinic) domain->x2lamda(coord,lamda);
-  } else {
-    if (triclinic == 0) {
-      coord[0] = xlo + random_equal->uniform() * (xhi-xlo);
-      coord[1] = ylo + random_equal->uniform() * (yhi-ylo);
-      coord[2] = zlo + random_equal->uniform() * (zhi-zlo);
-    } else {
-      lamda[0] = random_equal->uniform();
-      lamda[1] = random_equal->uniform();
-      lamda[2] = random_equal->uniform();
-
-      // wasteful, but necessary
-
-      if (lamda[0] == 1.0) lamda[0] = 0.0;
-      if (lamda[1] == 1.0) lamda[1] = 0.0;
-      if (lamda[2] == 1.0) lamda[2] = 0.0;
-
-      domain->lamda2x(lamda,coord);
-    }
-  }
-
-  int proc_flag = 0;
-  if (triclinic == 0) {
-    domain->remap(coord);
-    if (!domain->inside(coord))
-      error->one(FLERR,"Fix vmmc put atom outside box");
-    if (coord[0] >= sublo[0] && coord[0] < subhi[0] &&
-        coord[1] >= sublo[1] && coord[1] < subhi[1] &&
-        coord[2] >= sublo[2] && coord[2] < subhi[2]) proc_flag = 1;
-  } else {
-    if (lamda[0] >= sublo[0] && lamda[0] < subhi[0] &&
-        lamda[1] >= sublo[1] && lamda[1] < subhi[1] &&
-        lamda[2] >= sublo[2] && lamda[2] < subhi[2]) proc_flag = 1;
-  }
-
-  int success = 0;
-  if (proc_flag) {
-    int ii = -1;
-    if (charge_flag) {
-      ii = atom->nlocal + atom->nghost;
-      if (ii >= atom->nmax) atom->avec->grow(0);
-      atom->q[ii] = charge;
-    }
-    double insertion_energy = energy(ii,nvmmc_type,-1,coord);
-
-    if (insertion_energy < MAXENERGYTEST &&
-        random_unequal->uniform() <
-        zz*volume*exp(-beta*insertion_energy)/(ngas+1)) {
-      atom->avec->create_atom(nvmmc_type,coord);
-      int m = atom->nlocal - 1;
-
-      // add to groups
-      // optionally add to type-based groups
-
-      atom->mask[m] = groupbitall;
-      for (int igroup = 0; igroup < ngrouptypes; igroup++) {
-        if (nvmmc_type == grouptypes[igroup])
-          atom->mask[m] |= grouptypebits[igroup];
-      }
-
-      atom->v[m][0] = random_unequal->gaussian()*sigma;
-      atom->v[m][1] = random_unequal->gaussian()*sigma;
-      atom->v[m][2] = random_unequal->gaussian()*sigma;
-      modify->create_attribute(m);
-
-      success = 1;
-    }
-  }
-
-  int success_all = 0;
-  MPI_Allreduce(&success,&success_all,1,MPI_INT,MPI_MAX,world);
-
-  if (success_all) {
-    atom->natoms++;
-    if (atom->tag_enable) {
-      atom->tag_extend();
-      if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-    }
-    atom->nghost = 0;
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-    update_gas_atoms_list();
-    ninsertion_successes += 1.0;
   }
 }
 
@@ -1280,239 +1031,6 @@ void FixVMMC::attempt_molecule_rotation()
 /* ----------------------------------------------------------------------
 ------------------------------------------------------------------------- */
 
-void FixVMMC::attempt_molecule_deletion()
-{
-  ndeletion_attempts += 1.0;
-
-  if (ngas == 0 || ngas <= min_ngas) return;
-
-  // work-around to avoid n=0 problem with fix rigid/nvt/small
-
-  if (rigidflag && ngas == natoms_per_molecule) return;
-
-  tagint deletion_molecule = pick_random_gas_molecule();
-  if (deletion_molecule == -1) return;
-
-  double deletion_energy_sum = molecule_energy(deletion_molecule);
-
-  if (random_equal->uniform() <
-      ngas*exp(beta*deletion_energy_sum)/(zz*volume*natoms_per_molecule)) {
-    int i = 0;
-    while (i < atom->nlocal) {
-      if (atom->molecule[i] == deletion_molecule) {
-        atom->avec->copy(atom->nlocal-1,i,1);
-        atom->nlocal--;
-      } else i++;
-    }
-    atom->natoms -= natoms_per_molecule;
-    if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-    atom->nghost = 0;
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-    update_gas_atoms_list();
-    ndeletion_successes += 1.0;
-  }
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_molecule_insertion()
-{
-  double lamda[3];
-  ninsertion_attempts += 1.0;
-
-  if (ngas >= max_ngas) return;
-
-  double com_coord[3];
-  if (region) {
-    int region_attempt = 0;
-    com_coord[0] = region_xlo + random_equal->uniform() *
-      (region_xhi-region_xlo);
-    com_coord[1] = region_ylo + random_equal->uniform() *
-      (region_yhi-region_ylo);
-    com_coord[2] = region_zlo + random_equal->uniform() *
-      (region_zhi-region_zlo);
-    while (region->match(com_coord[0],com_coord[1],
-                                           com_coord[2]) == 0) {
-      com_coord[0] = region_xlo + random_equal->uniform() *
-        (region_xhi-region_xlo);
-      com_coord[1] = region_ylo + random_equal->uniform() *
-        (region_yhi-region_ylo);
-      com_coord[2] = region_zlo + random_equal->uniform() *
-        (region_zhi-region_zlo);
-      region_attempt++;
-      if (region_attempt >= max_region_attempts) return;
-    }
-    if (triclinic) domain->x2lamda(com_coord,lamda);
-  } else {
-    if (triclinic == 0) {
-      com_coord[0] = xlo + random_equal->uniform() * (xhi-xlo);
-      com_coord[1] = ylo + random_equal->uniform() * (yhi-ylo);
-      com_coord[2] = zlo + random_equal->uniform() * (zhi-zlo);
-    } else {
-      lamda[0] = random_equal->uniform();
-      lamda[1] = random_equal->uniform();
-      lamda[2] = random_equal->uniform();
-
-      // wasteful, but necessary
-
-      if (lamda[0] == 1.0) lamda[0] = 0.0;
-      if (lamda[1] == 1.0) lamda[1] = 0.0;
-      if (lamda[2] == 1.0) lamda[2] = 0.0;
-
-      domain->lamda2x(lamda,com_coord);
-    }
-  }
-
-  // generate point in unit cube
-  // then restrict to unit sphere
-
-  double r[3],rotmat[3][3],quat[4];
-  double rsq = 1.1;
-  while (rsq > 1.0) {
-    r[0] = 2.0*random_equal->uniform() - 1.0;
-    r[1] = 2.0*random_equal->uniform() - 1.0;
-    r[2] = 2.0*random_equal->uniform() - 1.0;
-    rsq = MathExtra::dot3(r, r);
-  }
-
-  double theta = random_equal->uniform() * MY_2PI;
-  MathExtra::norm3(r);
-  MathExtra::axisangle_to_quat(r,theta,quat);
-  MathExtra::quat_to_mat(quat,rotmat);
-
-  double insertion_energy = 0.0;
-  auto procflag = new bool[natoms_per_molecule];
-
-  for (int i = 0; i < natoms_per_molecule; i++) {
-    MathExtra::matvec(rotmat,onemols[imol]->x[i],molcoords[i]);
-    molcoords[i][0] += com_coord[0];
-    molcoords[i][1] += com_coord[1];
-    molcoords[i][2] += com_coord[2];
-
-    // use temporary variable for remapped position
-    // so unmapped position is preserved in molcoords
-
-    double xtmp[3];
-    xtmp[0] = molcoords[i][0];
-    xtmp[1] = molcoords[i][1];
-    xtmp[2] = molcoords[i][2];
-    domain->remap(xtmp);
-    if (!domain->inside(xtmp))
-      error->one(FLERR,"Fix vmmc put atom outside box");
-
-    procflag[i] = false;
-    if (triclinic == 0) {
-      if (xtmp[0] >= sublo[0] && xtmp[0] < subhi[0] &&
-          xtmp[1] >= sublo[1] && xtmp[1] < subhi[1] &&
-          xtmp[2] >= sublo[2] && xtmp[2] < subhi[2]) procflag[i] = true;
-    } else {
-      domain->x2lamda(xtmp,lamda);
-      if (lamda[0] >= sublo[0] && lamda[0] < subhi[0] &&
-          lamda[1] >= sublo[1] && lamda[1] < subhi[1] &&
-          lamda[2] >= sublo[2] && lamda[2] < subhi[2]) procflag[i] = true;
-    }
-
-    if (procflag[i]) {
-      int ii = -1;
-      if (onemols[imol]->qflag == 1) {
-        ii = atom->nlocal + atom->nghost;
-        if (ii >= atom->nmax) atom->avec->grow(0);
-        atom->q[ii] = onemols[imol]->q[i];
-      }
-      insertion_energy += energy(ii,onemols[imol]->type[i],-1,xtmp);
-    }
-  }
-
-  double insertion_energy_sum = 0.0;
-  MPI_Allreduce(&insertion_energy,&insertion_energy_sum,1,
-                MPI_DOUBLE,MPI_SUM,world);
-
-  if (insertion_energy_sum < MAXENERGYTEST &&
-      random_equal->uniform() < zz*volume*natoms_per_molecule*
-      exp(-beta*insertion_energy_sum)/(ngas + natoms_per_molecule)) {
-
-    tagint maxmol = 0;
-    for (int i = 0; i < atom->nlocal; i++) maxmol = MAX(maxmol,atom->molecule[i]);
-    tagint maxmol_all;
-    MPI_Allreduce(&maxmol,&maxmol_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
-    maxmol_all++;
-    if (maxmol_all >= MAXTAGINT)
-      error->all(FLERR,"Fix vmmc ran out of available molecule IDs");
-
-    tagint maxtag = 0;
-    for (int i = 0; i < atom->nlocal; i++) maxtag = MAX(maxtag,atom->tag[i]);
-    tagint maxtag_all;
-    MPI_Allreduce(&maxtag,&maxtag_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
-
-    int nlocalprev = atom->nlocal;
-
-    double vnew[3];
-    vnew[0] = random_equal->gaussian()*sigma;
-    vnew[1] = random_equal->gaussian()*sigma;
-    vnew[2] = random_equal->gaussian()*sigma;
-
-    for (int i = 0; i < natoms_per_molecule; i++) {
-      if (procflag[i]) {
-        atom->avec->create_atom(onemols[imol]->type[i],molcoords[i]);
-        int m = atom->nlocal - 1;
-
-        // add to groups
-        // optionally add to type-based groups
-
-        atom->mask[m] = groupbitall;
-        for (int igroup = 0; igroup < ngrouptypes; igroup++) {
-          if (nvmmc_type == grouptypes[igroup])
-            atom->mask[m] |= grouptypebits[igroup];
-        }
-
-        atom->image[m] = imagezero;
-        domain->remap(atom->x[m],atom->image[m]);
-        atom->molecule[m] = maxmol_all;
-        if (maxtag_all+i+1 >= MAXTAGINT)
-          error->all(FLERR,"Fix vmmc ran out of available atom IDs");
-        atom->tag[m] = maxtag_all + i + 1;
-        atom->v[m][0] = vnew[0];
-        atom->v[m][1] = vnew[1];
-        atom->v[m][2] = vnew[2];
-
-        atom->add_molecule_atom(onemols[imol],i,m,maxtag_all);
-        modify->create_attribute(m);
-      }
-    }
-
-    // FixRigidSmall::set_molecule stores rigid body attributes
-    // FixShake::set_molecule stores shake info for molecule
-
-    for (int submol = 0; submol < nmol; ++submol) {
-      if (rigidflag)
-        fixrigid->set_molecule(nlocalprev,maxtag_all,submol,com_coord,vnew,quat);
-      else if (shakeflag)
-        fixshake->set_molecule(nlocalprev,maxtag_all,submol,com_coord,vnew,quat);
-    }
-    atom->natoms += natoms_per_molecule;
-    if (atom->natoms < 0)
-      error->all(FLERR,"Too many total atoms");
-    atom->nbonds += onemols[imol]->nbonds;
-    atom->nangles += onemols[imol]->nangles;
-    atom->ndihedrals += onemols[imol]->ndihedrals;
-    atom->nimpropers += onemols[imol]->nimpropers;
-    if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-    atom->nghost = 0;
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-    update_gas_atoms_list();
-    ninsertion_successes += 1.0;
-  }
-  delete[] procflag;
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
 void FixVMMC::attempt_atomic_translation_full()
 {
   ntranslation_attempts += 1.0;
@@ -1593,166 +1111,6 @@ void FixVMMC::attempt_atomic_translation_full()
         x[i][2] = xtmp_all[2];
       }
     }
-    energy_stored = energy_before;
-  }
-  update_gas_atoms_list();
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_atomic_deletion_full()
-{
-  double q_tmp;
-  const int q_flag = atom->q_flag;
-
-  ndeletion_attempts += 1.0;
-
-  if (ngas == 0 || ngas <= min_ngas) return;
-
-  double energy_before = energy_stored;
-
-  const int i = pick_random_gas_atom();
-
-  int tmpmask;
-  if (i >= 0) {
-    tmpmask = atom->mask[i];
-    atom->mask[i] = exclusion_group_bit;
-    if (q_flag) {
-      q_tmp = atom->q[i];
-      atom->q[i] = 0.0;
-    }
-  }
-  if (force->kspace) force->kspace->qsum_qsq();
-  if (force->pair->tail_flag) force->pair->reinit();
-  double energy_after = energy_full();
-
-  if (random_equal->uniform() <
-      ngas*exp(beta*(energy_before - energy_after))/(zz*volume)) {
-    if (i >= 0) {
-      atom->avec->copy(atom->nlocal-1,i,1);
-      atom->nlocal--;
-    }
-    atom->natoms--;
-    if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-    ndeletion_successes += 1.0;
-    energy_stored = energy_after;
-  } else {
-    if (i >= 0) {
-      atom->mask[i] = tmpmask;
-      if (q_flag) atom->q[i] = q_tmp;
-    }
-    if (force->kspace) force->kspace->qsum_qsq();
-    if (force->pair->tail_flag) force->pair->reinit();
-    energy_stored = energy_before;
-  }
-  update_gas_atoms_list();
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_atomic_insertion_full()
-{
-  double lamda[3];
-  ninsertion_attempts += 1.0;
-
-  if (ngas >= max_ngas) return;
-
-  double energy_before = energy_stored;
-
-  double coord[3];
-  if (region) {
-    int region_attempt = 0;
-    coord[0] = region_xlo + random_equal->uniform() * (region_xhi-region_xlo);
-    coord[1] = region_ylo + random_equal->uniform() * (region_yhi-region_ylo);
-    coord[2] = region_zlo + random_equal->uniform() * (region_zhi-region_zlo);
-    while (region->match(coord[0],coord[1],coord[2]) == 0) {
-      coord[0] = region_xlo + random_equal->uniform() * (region_xhi-region_xlo);
-      coord[1] = region_ylo + random_equal->uniform() * (region_yhi-region_ylo);
-      coord[2] = region_zlo + random_equal->uniform() * (region_zhi-region_zlo);
-      region_attempt++;
-      if (region_attempt >= max_region_attempts) return;
-    }
-    if (triclinic) domain->x2lamda(coord,lamda);
-  } else {
-    if (triclinic == 0) {
-      coord[0] = xlo + random_equal->uniform() * (xhi-xlo);
-      coord[1] = ylo + random_equal->uniform() * (yhi-ylo);
-      coord[2] = zlo + random_equal->uniform() * (zhi-zlo);
-    } else {
-      lamda[0] = random_equal->uniform();
-      lamda[1] = random_equal->uniform();
-      lamda[2] = random_equal->uniform();
-
-      // wasteful, but necessary
-
-      if (lamda[0] == 1.0) lamda[0] = 0.0;
-      if (lamda[1] == 1.0) lamda[1] = 0.0;
-      if (lamda[2] == 1.0) lamda[2] = 0.0;
-
-      domain->lamda2x(lamda,coord);
-    }
-  }
-
-  int proc_flag = 0;
-  if (triclinic == 0) {
-    domain->remap(coord);
-    if (!domain->inside(coord))
-      error->one(FLERR,"Fix vmmc put atom outside box");
-    if (coord[0] >= sublo[0] && coord[0] < subhi[0] &&
-        coord[1] >= sublo[1] && coord[1] < subhi[1] &&
-        coord[2] >= sublo[2] && coord[2] < subhi[2]) proc_flag = 1;
-  } else {
-    if (lamda[0] >= sublo[0] && lamda[0] < subhi[0] &&
-        lamda[1] >= sublo[1] && lamda[1] < subhi[1] &&
-        lamda[2] >= sublo[2] && lamda[2] < subhi[2]) proc_flag = 1;
-  }
-
-  if (proc_flag) {
-    atom->avec->create_atom(nvmmc_type,coord);
-    int m = atom->nlocal - 1;
-
-    // add to groups
-    // optionally add to type-based groups
-
-    atom->mask[m] = groupbitall;
-    for (int igroup = 0; igroup < ngrouptypes; igroup++) {
-      if (nvmmc_type == grouptypes[igroup])
-        atom->mask[m] |= grouptypebits[igroup];
-    }
-
-    atom->v[m][0] = random_unequal->gaussian()*sigma;
-    atom->v[m][1] = random_unequal->gaussian()*sigma;
-    atom->v[m][2] = random_unequal->gaussian()*sigma;
-    if (charge_flag) atom->q[m] = charge;
-    modify->create_attribute(m);
-  }
-
-  atom->natoms++;
-  if (atom->tag_enable) {
-    atom->tag_extend();
-    if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-  }
-  atom->nghost = 0;
-  if (triclinic) domain->x2lamda(atom->nlocal);
-  comm->borders();
-  if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-  if (force->kspace) force->kspace->qsum_qsq();
-  if (force->pair->tail_flag) force->pair->reinit();
-  double energy_after = energy_full();
-
-  if (energy_after < MAXENERGYTEST &&
-      random_equal->uniform() <
-      zz*volume*exp(beta*(energy_before - energy_after))/(ngas+1)) {
-
-    ninsertion_successes += 1.0;
-    energy_stored = energy_after;
-  } else {
-    atom->natoms--;
-    if (proc_flag) atom->nlocal--;
-    if (force->kspace) force->kspace->qsum_qsq();
-    if (force->pair->tail_flag) force->pair->reinit();
     energy_stored = energy_before;
   }
   update_gas_atoms_list();
@@ -1948,291 +1306,6 @@ void FixVMMC::attempt_molecule_rotation_full()
 }
 
 /* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_molecule_deletion_full()
-{
-  ndeletion_attempts += 1.0;
-
-  if (ngas == 0 || ngas <= min_ngas) return;
-
-  // work-around to avoid n=0 problem with fix rigid/nvt/small
-
-  if (rigidflag && ngas == natoms_per_molecule) return;
-
-  tagint deletion_molecule = pick_random_gas_molecule();
-  if (deletion_molecule == -1) return;
-
-  double energy_before = energy_stored;
-
-  // check nmolq, grow arrays if necessary
-
-  int nmolq = 0;
-  for (int i = 0; i < atom->nlocal; i++)
-    if (atom->molecule[i] == deletion_molecule)
-      if (atom->q_flag) nmolq++;
-
-  if (nmolq > nmaxmolatoms)
-    grow_molecule_arrays(nmolq);
-
-  int m = 0;
-  int *tmpmask = new int[atom->nlocal];
-  for (int i = 0; i < atom->nlocal; i++) {
-    if (atom->molecule[i] == deletion_molecule) {
-      tmpmask[i] = atom->mask[i];
-      atom->mask[i] = exclusion_group_bit;
-      toggle_intramolecular(i);
-      if (atom->q_flag) {
-        molq[m] = atom->q[i];
-        m++;
-        atom->q[i] = 0.0;
-      }
-    }
-  }
-  if (force->kspace) force->kspace->qsum_qsq();
-  if (force->pair->tail_flag) force->pair->reinit();
-  double energy_after = energy_full();
-
-  // energy_before corrected by energy_intra
-
-  double deltaphi = ngas*exp(beta*((energy_before - energy_intra) - energy_after))/(zz*volume*natoms_per_molecule);
-
-  if (random_equal->uniform() < deltaphi) {
-    int i = 0;
-    while (i < atom->nlocal) {
-      if (atom->molecule[i] == deletion_molecule) {
-        atom->avec->copy(atom->nlocal-1,i,1);
-        atom->nlocal--;
-      } else i++;
-    }
-    atom->natoms -= natoms_per_molecule;
-    if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-    ndeletion_successes += 1.0;
-    energy_stored = energy_after;
-  } else {
-    energy_stored = energy_before;
-    int m = 0;
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (atom->molecule[i] == deletion_molecule) {
-        atom->mask[i] = tmpmask[i];
-        toggle_intramolecular(i);
-        if (atom->q_flag) {
-          atom->q[i] = molq[m];
-          m++;
-        }
-      }
-    }
-    if (force->kspace) force->kspace->qsum_qsq();
-    if (force->pair->tail_flag) force->pair->reinit();
-  }
-  update_gas_atoms_list();
-  delete[] tmpmask;
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_molecule_insertion_full()
-{
-  double lamda[3];
-  ninsertion_attempts += 1.0;
-
-  if (ngas >= max_ngas) return;
-
-  double energy_before = energy_stored;
-
-  tagint maxmol = 0;
-  for (int i = 0; i < atom->nlocal; i++) maxmol = MAX(maxmol,atom->molecule[i]);
-  tagint maxmol_all;
-  MPI_Allreduce(&maxmol,&maxmol_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
-  maxmol_all++;
-  if (maxmol_all >= MAXTAGINT)
-    error->all(FLERR,"Fix vmmc ran out of available molecule IDs");
-  int insertion_molecule = maxmol_all;
-
-  tagint maxtag = 0;
-  for (int i = 0; i < atom->nlocal; i++) maxtag = MAX(maxtag,atom->tag[i]);
-  tagint maxtag_all;
-  MPI_Allreduce(&maxtag,&maxtag_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
-
-  int nlocalprev = atom->nlocal;
-
-  double com_coord[3];
-  if (region) {
-    int region_attempt = 0;
-    com_coord[0] = region_xlo + random_equal->uniform() *
-      (region_xhi-region_xlo);
-    com_coord[1] = region_ylo + random_equal->uniform() *
-      (region_yhi-region_ylo);
-    com_coord[2] = region_zlo + random_equal->uniform() *
-      (region_zhi-region_zlo);
-    while (region->match(com_coord[0],com_coord[1],
-                                           com_coord[2]) == 0) {
-      com_coord[0] = region_xlo + random_equal->uniform() *
-        (region_xhi-region_xlo);
-      com_coord[1] = region_ylo + random_equal->uniform() *
-        (region_yhi-region_ylo);
-      com_coord[2] = region_zlo + random_equal->uniform() *
-        (region_zhi-region_zlo);
-      region_attempt++;
-      if (region_attempt >= max_region_attempts) return;
-    }
-    if (triclinic) domain->x2lamda(com_coord,lamda);
-  } else {
-    if (triclinic == 0) {
-      com_coord[0] = xlo + random_equal->uniform() * (xhi-xlo);
-      com_coord[1] = ylo + random_equal->uniform() * (yhi-ylo);
-      com_coord[2] = zlo + random_equal->uniform() * (zhi-zlo);
-    } else {
-      lamda[0] = random_equal->uniform();
-      lamda[1] = random_equal->uniform();
-      lamda[2] = random_equal->uniform();
-
-      // wasteful, but necessary
-
-      if (lamda[0] == 1.0) lamda[0] = 0.0;
-      if (lamda[1] == 1.0) lamda[1] = 0.0;
-      if (lamda[2] == 1.0) lamda[2] = 0.0;
-
-      domain->lamda2x(lamda,com_coord);
-    }
-
-  }
-
-  // generate point in unit cube
-  // then restrict to unit sphere
-
-  double r[3],rotmat[3][3],quat[4];
-  double rsq = 1.1;
-  while (rsq > 1.0) {
-    r[0] = 2.0*random_equal->uniform() - 1.0;
-    r[1] = 2.0*random_equal->uniform() - 1.0;
-    r[2] = 2.0*random_equal->uniform() - 1.0;
-    rsq = MathExtra::dot3(r, r);
-  }
-
-  double theta = random_equal->uniform() * MY_2PI;
-  MathExtra::norm3(r);
-  MathExtra::axisangle_to_quat(r,theta,quat);
-  MathExtra::quat_to_mat(quat,rotmat);
-
-  double vnew[3];
-  vnew[0] = random_equal->gaussian()*sigma;
-  vnew[1] = random_equal->gaussian()*sigma;
-  vnew[2] = random_equal->gaussian()*sigma;
-
-  for (int i = 0; i < natoms_per_molecule; i++) {
-    double xtmp[3];
-    MathExtra::matvec(rotmat,onemols[imol]->x[i],xtmp);
-    xtmp[0] += com_coord[0];
-    xtmp[1] += com_coord[1];
-    xtmp[2] += com_coord[2];
-
-    // need to adjust image flags in remap()
-
-    imageint imagetmp = imagezero;
-    domain->remap(xtmp,imagetmp);
-    if (!domain->inside(xtmp))
-      error->one(FLERR,"Fix vmmc put atom outside box");
-
-    int proc_flag = 0;
-    if (triclinic == 0) {
-      if (xtmp[0] >= sublo[0] && xtmp[0] < subhi[0] &&
-          xtmp[1] >= sublo[1] && xtmp[1] < subhi[1] &&
-          xtmp[2] >= sublo[2] && xtmp[2] < subhi[2]) proc_flag = 1;
-    } else {
-      domain->x2lamda(xtmp,lamda);
-      if (lamda[0] >= sublo[0] && lamda[0] < subhi[0] &&
-          lamda[1] >= sublo[1] && lamda[1] < subhi[1] &&
-          lamda[2] >= sublo[2] && lamda[2] < subhi[2]) proc_flag = 1;
-    }
-
-    if (proc_flag) {
-      atom->avec->create_atom(onemols[imol]->type[i],xtmp);
-      int m = atom->nlocal - 1;
-
-      // add to groups
-      // optionally add to type-based groups
-
-      atom->mask[m] = groupbitall;
-      for (int igroup = 0; igroup < ngrouptypes; igroup++) {
-        if (nvmmc_type == grouptypes[igroup])
-          atom->mask[m] |= grouptypebits[igroup];
-      }
-
-      atom->image[m] = imagetmp;
-      atom->molecule[m] = insertion_molecule;
-      if (maxtag_all+i+1 >= MAXTAGINT)
-        error->all(FLERR,"Fix vmmc ran out of available atom IDs");
-      atom->tag[m] = maxtag_all + i + 1;
-      atom->v[m][0] = vnew[0];
-      atom->v[m][1] = vnew[1];
-      atom->v[m][2] = vnew[2];
-
-      atom->add_molecule_atom(onemols[imol],i,m,maxtag_all);
-      modify->create_attribute(m);
-    }
-  }
-
-  // FixRigidSmall::set_molecule stores rigid body attributes
-  // FixShake::set_molecule stores shake info for molecule
-
-  for (int submol = 0; submol < nmol; ++submol) {
-    if (rigidflag)
-      fixrigid->set_molecule(nlocalprev,maxtag_all,submol,com_coord,vnew,quat);
-    else if (shakeflag)
-      fixshake->set_molecule(nlocalprev,maxtag_all,submol,com_coord,vnew,quat);
-  }
-  atom->natoms += natoms_per_molecule;
-  if (atom->natoms < 0)
-    error->all(FLERR,"Too many total atoms");
-  atom->nbonds += onemols[imol]->nbonds;
-  atom->nangles += onemols[imol]->nangles;
-  atom->ndihedrals += onemols[imol]->ndihedrals;
-  atom->nimpropers += onemols[imol]->nimpropers;
-  if (atom->map_style != Atom::MAP_NONE) atom->map_init();
-  atom->nghost = 0;
-  if (triclinic) domain->x2lamda(atom->nlocal);
-  comm->borders();
-  if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-  if (force->kspace) force->kspace->qsum_qsq();
-  if (force->pair->tail_flag) force->pair->reinit();
-  double energy_after = energy_full();
-
-  // energy_after corrected by energy_intra
-
-  double deltaphi = zz*volume*natoms_per_molecule*
-    exp(beta*(energy_before - (energy_after - energy_intra)))/(ngas + natoms_per_molecule);
-
-  if (energy_after < MAXENERGYTEST &&
-      random_equal->uniform() < deltaphi) {
-
-    ninsertion_successes += 1.0;
-    energy_stored = energy_after;
-
-  } else {
-
-    atom->nbonds -= onemols[imol]->nbonds;
-    atom->nangles -= onemols[imol]->nangles;
-    atom->ndihedrals -= onemols[imol]->ndihedrals;
-    atom->nimpropers -= onemols[imol]->nimpropers;
-    atom->natoms -= natoms_per_molecule;
-
-    energy_stored = energy_before;
-    int i = 0;
-    while (i < atom->nlocal) {
-      if (atom->molecule[i] == insertion_molecule) {
-        atom->avec->copy(atom->nlocal-1,i,1);
-        atom->nlocal--;
-      } else i++;
-    }
-    if (force->kspace) force->kspace->qsum_qsq();
-    if (force->pair->tail_flag) force->pair->reinit();
-  }
-  update_gas_atoms_list();
-}
-
-/* ----------------------------------------------------------------------
    compute particle's interaction energy with the rest of the system by
    looping over all atoms in the sub-domain including ghosts.
 ------------------------------------------------------------------------- */
@@ -2257,8 +1330,6 @@ double FixVMMC::energy(int i, int itype, tagint imolecule, double *coord)
   for (int j = 0; j < nall; j++) {
 
     if (i == j) continue;
-    if (exchmode == EXCHMOL || movemode == MOVEMOL)
-      if (imolecule == molecule[j]) continue;
 
     delx = coord[0] - x[j][0];
     dely = coord[1] - x[j][1];
@@ -2329,11 +1400,7 @@ double FixVMMC::energy_full()
     tagint *molecule = atom->molecule;
     int nall = atom->nlocal + atom->nghost;
     for (int i = 0; i < atom->nlocal; i++) {
-      if (exchmode == EXCHMOL || movemode == MOVEMOL)
-        imolecule = molecule[i];
       for (int j = i+1; j < nall; j++) {
-        if (exchmode == EXCHMOL || movemode == MOVEMOL)
-          if (imolecule == molecule[j]) continue;
 
         delx = x[i][0] - x[j][0];
         dely = x[i][1] - x[j][1];
@@ -2457,61 +1524,18 @@ void FixVMMC::update_gas_atoms_list()
     memory->sfree(local_gas_list);
     vmmc_nmax = atom->nmax;
     local_gas_list = (int *) memory->smalloc(vmmc_nmax*sizeof(int),
-     "GCMC:local_gas_list");
+     "VMMC:local_gas_list");
   }
 
   ngas_local = 0;
 
   if (region) {
 
-    if (exchmode == EXCHMOL || movemode == MOVEMOL) {
-
-      tagint maxmol = 0;
-      for (int i = 0; i < nlocal; i++) maxmol = MAX(maxmol,molecule[i]);
-      tagint maxmol_all;
-      MPI_Allreduce(&maxmol,&maxmol_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
-      auto comx = new double[maxmol_all];
-      auto comy = new double[maxmol_all];
-      auto comz = new double[maxmol_all];
-      for (int imolecule = 0; imolecule < maxmol_all; imolecule++) {
-        for (int i = 0; i < nlocal; i++) {
-          if (molecule[i] == imolecule) {
-            mask[i] |= molecule_group_bit;
-          } else {
-            mask[i] &= molecule_group_inversebit;
-          }
-        }
-        double com[3];
-        com[0] = com[1] = com[2] = 0.0;
-        group->xcm(molecule_group,gas_mass,com);
-
-        // remap unwrapped com into periodic box
-
-        domain->remap(com);
-        comx[imolecule] = com[0];
-        comy[imolecule] = com[1];
-        comz[imolecule] = com[2];
-      }
-
-      for (int i = 0; i < nlocal; i++) {
-        if (mask[i] & groupbit) {
-          if (region->match(comx[molecule[i]],
-             comy[molecule[i]],comz[molecule[i]]) == 1) {
-            local_gas_list[ngas_local] = i;
-            ngas_local++;
-          }
-        }
-      }
-      delete[] comx;
-      delete[] comy;
-      delete[] comz;
-    } else {
-      for (int i = 0; i < nlocal; i++) {
-        if (mask[i] & groupbit) {
-          if (region->match(x[i][0],x[i][1],x[i][2]) == 1) {
-            local_gas_list[ngas_local] = i;
-            ngas_local++;
-          }
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+        if (region->match(x[i][0],x[i][1],x[i][2]) == 1) {
+          local_gas_list[ngas_local] = i;
+          ngas_local++;
         }
       }
     }
@@ -2538,10 +1562,6 @@ double FixVMMC::compute_vector(int n)
 {
   if (n == 0) return ntranslation_attempts;
   if (n == 1) return ntranslation_successes;
-  if (n == 2) return ninsertion_attempts;
-  if (n == 3) return ninsertion_successes;
-  if (n == 4) return ndeletion_attempts;
-  if (n == 5) return ndeletion_successes;
   if (n == 6) return nrotation_attempts;
   if (n == 7) return nrotation_successes;
   return 0.0;
@@ -2572,10 +1592,6 @@ void FixVMMC::write_restart(FILE *fp)
   list[n++] = ntranslation_successes;
   list[n++] = nrotation_attempts;
   list[n++] = nrotation_successes;
-  list[n++] = ndeletion_attempts;
-  list[n++] = ndeletion_successes;
-  list[n++] = ninsertion_attempts;
-  list[n++] = ninsertion_successes;
   list[n++] = ubuf(update->ntimestep).d;
 
   if (comm->me == 0) {
@@ -2606,10 +1622,6 @@ void FixVMMC::restart(char *buf)
   ntranslation_successes = list[n++];
   nrotation_attempts     = list[n++];
   nrotation_successes    = list[n++];
-  ndeletion_attempts     = list[n++];
-  ndeletion_successes    = list[n++];
-  ninsertion_attempts    = list[n++];
-  ninsertion_successes   = list[n++];
 
   bigint ntimestep_restart = (bigint) ubuf(list[n++]).i;
   if (ntimestep_restart != update->ntimestep)

--- a/src/MC/fix_vmmc.cpp
+++ b/src/MC/fix_vmmc.cpp
@@ -39,7 +39,6 @@
 #include "math_extra.h"
 #include "memory.h"
 #include "modify.h"
-#include "molecule.h"
 #include "neighbor.h"
 #include "pair.h"
 #include "random_park.h"
@@ -73,9 +72,7 @@ enum { NONE, MOVEATOM, MOVEMOL };    // movemode
 FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
     Fix(lmp, narg, arg), region(nullptr), idregion(nullptr), full_flag(false),
     groupstrings(nullptr), grouptypestrings(nullptr), grouptypebits(nullptr), grouptypes(nullptr),
-    local_gas_list(nullptr), molcoords(nullptr), molq(nullptr), molimage(nullptr),
-    random_equal(nullptr), random_unequal(nullptr), fixrigid(nullptr), fixshake(nullptr),
-    idrigid(nullptr), idshake(nullptr)
+    local_gas_list(nullptr), random_equal(nullptr), random_unequal(nullptr)
 {
   if (narg < 11) utils::missing_cmd_args(FLERR, "fix vmmc", error);
 
@@ -164,25 +161,6 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
   if (charge_flag && atom->q == nullptr)
     error->all(FLERR,"Fix vmmc atom has charge, but atom style does not");
 
-  if (rigidflag && exchmode == EXCHATOM)
-    error->all(FLERR,"Cannot use fix vmmc rigid and not molecule");
-  if (shakeflag && exchmode == EXCHATOM)
-    error->all(FLERR,"Cannot use fix vmmc shake and not molecule");
-  if (rigidflag && shakeflag)
-    error->all(FLERR,"Cannot use fix vmmc rigid and shake");
-  if (rigidflag && (nmcmoves > 0))
-    error->all(FLERR,"Cannot use fix vmmc rigid with MC moves");
-  if (shakeflag && (nmcmoves > 0))
-    error->all(FLERR,"Cannot use fix vmmc shake with MC moves");
-
-  // setup of array of coordinates for molecule insertion
-  // also used by rotation moves for any molecule
-
-  if (exchmode == EXCHATOM) natoms_per_molecule = 1;
-  else natoms_per_molecule = onemols[imol]->natoms;
-  nmaxmolatoms = natoms_per_molecule;
-  grow_molecule_arrays(nmaxmolatoms);
-
   // compute the number of MC cycles that occur nevery timesteps
 
   ncycles = nexchanges + nmcmoves;
@@ -218,8 +196,6 @@ void FixVMMC::options(int narg, char **arg)
   exchmode = EXCHATOM;
   movemode = NONE;
   patomtrans = 0.0;
-  pmoltrans = 0.0;
-  pmolrotate = 0.0;
   pmctot = 0.0;
   max_rotation_angle = 10*MY_PI/180;
   region_volume = 0;
@@ -232,8 +208,6 @@ void FixVMMC::options(int narg, char **arg)
   pressure_flag = false;
   pressure = 0.0;
   fugacity_coeff = 1.0;
-  rigidflag = 0;
-  shakeflag = 0;
   charge = 0.0;
   charge_flag = false;
   full_flag = false;
@@ -257,11 +231,9 @@ void FixVMMC::options(int narg, char **arg)
     if (strcmp(arg[iarg],"mcmoves") == 0) {
       if (iarg+4 > narg) error->all(FLERR,"Illegal fix vmmc command");
       patomtrans = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      pmoltrans = utils::numeric(FLERR,arg[iarg+2],false,lmp);
-      pmolrotate = utils::numeric(FLERR,arg[iarg+3],false,lmp);
-      if (patomtrans < 0 || pmoltrans < 0 || pmolrotate < 0)
+      if (patomtrans < 0)
         error->all(FLERR,"Illegal fix vmmc command");
-      pmctot = patomtrans + pmoltrans + pmolrotate;
+      pmctot = patomtrans;
       if (pmctot <= 0)
         error->all(FLERR,"Illegal fix vmmc command");
       iarg += 4;
@@ -290,19 +262,7 @@ void FixVMMC::options(int narg, char **arg)
       charge = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       charge_flag = true;
       iarg += 2;
-    } else if (strcmp(arg[iarg],"rigid") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      delete [] idrigid;
-      idrigid = utils::strdup(arg[iarg+1]);
-      rigidflag = 1;
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"shake") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      delete [] idshake;
-      idshake = utils::strdup(arg[iarg+1]);
-      shakeflag = 1;
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"full_energy") == 0) {
+    }  else if (strcmp(arg[iarg],"full_energy") == 0) {
       full_flag = true;
       iarg += 1;
     } else if (strcmp(arg[iarg],"group") == 0) {
@@ -367,12 +327,6 @@ FixVMMC::~FixVMMC()
   delete random_unequal;
 
   memory->destroy(local_gas_list);
-  memory->destroy(molcoords);
-  memory->destroy(molq);
-  memory->destroy(molimage);
-
-  delete[] idrigid;
-  delete[] idshake;
 
   if (ngroups > 0) {
     for (int igroup = 0; igroup < ngroups; igroup++)
@@ -476,26 +430,15 @@ void FixVMMC::init()
   // set probabilities for MC moves
 
   if (nmcmoves > 0) {
-    if (pmctot == 0.0)
+    if (pmctot == 0.0) {
       if (exchmode == EXCHATOM) {
         movemode = MOVEATOM;
         patomtrans = 1.0;
-        pmoltrans = 0.0;
-        pmolrotate = 0.0;
-      } else {
-        movemode = MOVEMOL;
-        patomtrans = 0.0;
-        pmoltrans = 0.5;
-        pmolrotate = 0.5;
       }
+    }
     else {
-      if (pmoltrans == 0.0 && pmolrotate == 0.0)
-        movemode = MOVEATOM;
-      else
-        movemode = MOVEMOL;
+      movemode = MOVEATOM;
       patomtrans /= pmctot;
-      pmoltrans /= pmctot;
-      pmolrotate /= pmctot;
     }
   } else movemode = NONE;
 
@@ -535,30 +478,6 @@ void FixVMMC::init()
     MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
     if (flagall)
       error->all(FLERR, "Fix vmmc cannot exchange individual atoms belonging to a molecule");
-  }
-
-  // if rigidflag defined, check for rigid/small fix
-  // its molecule template must be same as this one
-
-  fixrigid = nullptr;
-  if (rigidflag) {
-    fixrigid = modify->get_fix_by_id(idrigid);
-    if (!fixrigid) error->all(FLERR,"Fix vmmc rigid fix ID {} does not exist", idrigid);
-    int tmp;
-    if (&onemols[imol] != (Molecule **) fixrigid->extract("onemol",tmp))
-      error->all(FLERR, "Fix vmmc and fix rigid/small not using same molecule template ID");
-  }
-
-  // if shakeflag defined, check for SHAKE fix
-  // its molecule template must be same as this one
-
-  fixshake = nullptr;
-  if (shakeflag) {
-    fixshake = modify->get_fix_by_id(idshake);
-    if (!fixshake) error->all(FLERR,"Fix vmmc shake fix ID {} does not exist", idshake);
-    int tmp;
-    if (&onemols[imol] != (Molecule **) fixshake->extract("onemol",tmp))
-      error->all(FLERR,"Fix vmmc and fix shake not using same molecule template ID");
   }
 
   if (domain->dimension == 2)
@@ -659,14 +578,6 @@ void FixVMMC::init()
     }
   }
 
-  // current implementation is broken using
-  // full_flag and translation/rotation of molecules
-  // on more than one processor.
-
-  if (full_flag && movemode == MOVEMOL && comm->nprocs > 1)
-    error->all(FLERR,"fix vmmc does currently not support full_energy "
-               "option with molecule MC moves on more than 1 MPI process.");
-
 }
 
 /* ----------------------------------------------------------------------
@@ -719,9 +630,6 @@ void FixVMMC::pre_exchange()
       if (ixm <= nmcmoves) {
         double xmcmove = random_equal->uniform();
         if (xmcmove < patomtrans) attempt_atomic_translation_full();
-        else if (xmcmove < patomtrans+pmoltrans) attempt_molecule_translation_full();
-        else attempt_molecule_rotation_full();
-
       }
     }
     if (triclinic) domain->x2lamda(atom->nlocal);
@@ -738,8 +646,6 @@ void FixVMMC::pre_exchange()
       if (ixm <= nmcmoves) {
         double xmcmove = random_equal->uniform();
         if (xmcmove < patomtrans) attempt_atomic_translation();
-        else if (xmcmove < patomtrans+pmoltrans) attempt_molecule_translation();
-        else attempt_molecule_rotation();
       }
     }
   }
@@ -820,211 +726,6 @@ void FixVMMC::attempt_atomic_translation()
     if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
     update_gas_atoms_list();
     ntranslation_successes += 1.0;
-  }
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_molecule_translation()
-{
-  ntranslation_attempts += 1.0;
-
-  if (ngas == 0) return;
-
-  tagint translation_molecule = pick_random_gas_molecule();
-  if (translation_molecule == -1) return;
-
-  double energy_before_sum = molecule_energy(translation_molecule);
-  if (overlap_flag && energy_before_sum > MAXENERGYTEST)
-    error->warning(FLERR,"Energy of old configuration in "
-                   "fix vmmc is > MAXENERGYTEST.");
-
-  double **x = atom->x;
-  double rx,ry,rz;
-  double com_displace[3],coord[3];
-  double rsq = 1.1;
-  while (rsq > 1.0) {
-    rx = 2*random_equal->uniform() - 1.0;
-    ry = 2*random_equal->uniform() - 1.0;
-    rz = 2*random_equal->uniform() - 1.0;
-    rsq = rx*rx + ry*ry + rz*rz;
-  }
-  com_displace[0] = displace*rx;
-  com_displace[1] = displace*ry;
-  com_displace[2] = displace*rz;
-
-  if (region) {
-    int *mask = atom->mask;
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (atom->molecule[i] == translation_molecule) {
-        mask[i] |= molecule_group_bit;
-      } else {
-        mask[i] &= molecule_group_inversebit;
-      }
-    }
-    double com[3];
-    com[0] = com[1] = com[2] = 0.0;
-    group->xcm(molecule_group,gas_mass,com);
-    coord[0] = com[0] + displace*rx;
-    coord[1] = com[1] + displace*ry;
-    coord[2] = com[2] + displace*rz;
-    while (region->match(coord[0],coord[1],coord[2]) == 0) {
-      rsq = 1.1;
-      while (rsq > 1.0) {
-        rx = 2*random_equal->uniform() - 1.0;
-        ry = 2*random_equal->uniform() - 1.0;
-        rz = 2*random_equal->uniform() - 1.0;
-        rsq = rx*rx + ry*ry + rz*rz;
-      }
-      coord[0] = com[0] + displace*rx;
-      coord[1] = com[1] + displace*ry;
-      coord[2] = com[2] + displace*rz;
-    }
-    com_displace[0] = displace*rx;
-    com_displace[1] = displace*ry;
-    com_displace[2] = displace*rz;
-  }
-
-  double energy_after = 0.0;
-  for (int i = 0; i < atom->nlocal; i++) {
-    if (atom->molecule[i] == translation_molecule) {
-      coord[0] = x[i][0] + com_displace[0];
-      coord[1] = x[i][1] + com_displace[1];
-      coord[2] = x[i][2] + com_displace[2];
-      if (!domain->inside_nonperiodic(coord))
-        error->one(FLERR,"Fix vmmc put atom outside box");
-      energy_after += energy(i,atom->type[i],translation_molecule,coord);
-    }
-  }
-
-  double energy_after_sum = 0.0;
-  MPI_Allreduce(&energy_after,&energy_after_sum,1,MPI_DOUBLE,MPI_SUM,world);
-
-  if (energy_after_sum < MAXENERGYTEST &&
-      random_equal->uniform() <
-      exp(beta*(energy_before_sum - energy_after_sum))) {
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (atom->molecule[i] == translation_molecule) {
-        x[i][0] += com_displace[0];
-        x[i][1] += com_displace[1];
-        x[i][2] += com_displace[2];
-      }
-    }
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    domain->pbc();
-    comm->exchange();
-    atom->nghost = 0;
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-    update_gas_atoms_list();
-    ntranslation_successes += 1.0;
-  }
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_molecule_rotation()
-{
-  nrotation_attempts += 1.0;
-
-  if (ngas == 0) return;
-
-  tagint rotation_molecule = pick_random_gas_molecule();
-  if (rotation_molecule == -1) return;
-
-  double energy_before_sum = molecule_energy(rotation_molecule);
-  if (overlap_flag && energy_before_sum > MAXENERGYTEST)
-    error->warning(FLERR,"Energy of old configuration in "
-                   "fix vmmc is > MAXENERGYTEST.");
-
-  int *mask = atom->mask;
-  int nmolcoords = 0;
-  for (int i = 0; i < atom->nlocal; i++) {
-    if (atom->molecule[i] == rotation_molecule) {
-      mask[i] |= molecule_group_bit;
-      nmolcoords++;
-    } else {
-      mask[i] &= molecule_group_inversebit;
-    }
-  }
-
-  if (nmolcoords > nmaxmolatoms)
-    grow_molecule_arrays(nmolcoords);
-
-  double com[3];
-  com[0] = com[1] = com[2] = 0.0;
-  group->xcm(molecule_group,gas_mass,com);
-
-  // generate point in unit cube
-  // then restrict to unit sphere
-
-  double r[3],rotmat[3][3],quat[4];
-  double rsq = 1.1;
-  while (rsq > 1.0) {
-    r[0] = 2.0*random_equal->uniform() - 1.0;
-    r[1] = 2.0*random_equal->uniform() - 1.0;
-    r[2] = 2.0*random_equal->uniform() - 1.0;
-    rsq = MathExtra::dot3(r, r);
-  }
-
-  double theta = random_equal->uniform() * max_rotation_angle;
-  MathExtra::norm3(r);
-  MathExtra::axisangle_to_quat(r,theta,quat);
-  MathExtra::quat_to_mat(quat,rotmat);
-
-  double **x = atom->x;
-  imageint *image = atom->image;
-  double energy_after = 0.0;
-  int n = 0;
-  for (int i = 0; i < atom->nlocal; i++) {
-    if (mask[i] & molecule_group_bit) {
-      double xtmp[3];
-      domain->unmap(x[i],image[i],xtmp);
-      xtmp[0] -= com[0];
-      xtmp[1] -= com[1];
-      xtmp[2] -= com[2];
-      MathExtra::matvec(rotmat,xtmp,molcoords[n]);
-      molcoords[n][0] += com[0];
-      molcoords[n][1] += com[1];
-      molcoords[n][2] += com[2];
-      xtmp[0] = molcoords[n][0];
-      xtmp[1] = molcoords[n][1];
-      xtmp[2] = molcoords[n][2];
-      domain->remap(xtmp);
-      if (!domain->inside(xtmp))
-        error->one(FLERR,"Fix vmmc put atom outside box");
-      energy_after += energy(i,atom->type[i],rotation_molecule,xtmp);
-      n++;
-    }
-  }
-
-  double energy_after_sum = 0.0;
-  MPI_Allreduce(&energy_after,&energy_after_sum,1,MPI_DOUBLE,MPI_SUM,world);
-
-  if (energy_after_sum < MAXENERGYTEST &&
-      random_equal->uniform() <
-      exp(beta*(energy_before_sum - energy_after_sum))) {
-    int n = 0;
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (mask[i] & molecule_group_bit) {
-        image[i] = imagezero;
-        x[i][0] = molcoords[n][0];
-        x[i][1] = molcoords[n][1];
-        x[i][2] = molcoords[n][2];
-        domain->remap(x[i],image[i]);
-        n++;
-      }
-    }
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    domain->pbc();
-    comm->exchange();
-    atom->nghost = 0;
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-    update_gas_atoms_list();
-    nrotation_successes += 1.0;
   }
 }
 
@@ -1117,195 +818,6 @@ void FixVMMC::attempt_atomic_translation_full()
 }
 
 /* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_molecule_translation_full()
-{
-  ntranslation_attempts += 1.0;
-
-  if (ngas == 0) return;
-
-  tagint translation_molecule = pick_random_gas_molecule();
-  if (translation_molecule == -1) return;
-
-  double energy_before = energy_stored;
-
-  double **x = atom->x;
-  double rx,ry,rz;
-  double com_displace[3],coord[3];
-  double rsq = 1.1;
-  while (rsq > 1.0) {
-    rx = 2*random_equal->uniform() - 1.0;
-    ry = 2*random_equal->uniform() - 1.0;
-    rz = 2*random_equal->uniform() - 1.0;
-    rsq = rx*rx + ry*ry + rz*rz;
-  }
-  com_displace[0] = displace*rx;
-  com_displace[1] = displace*ry;
-  com_displace[2] = displace*rz;
-
-  if (region) {
-    int *mask = atom->mask;
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (atom->molecule[i] == translation_molecule) {
-        mask[i] |= molecule_group_bit;
-      } else {
-        mask[i] &= molecule_group_inversebit;
-      }
-    }
-    double com[3];
-    com[0] = com[1] = com[2] = 0.0;
-    group->xcm(molecule_group,gas_mass,com);
-    coord[0] = com[0] + displace*rx;
-    coord[1] = com[1] + displace*ry;
-    coord[2] = com[2] + displace*rz;
-    while (region->match(coord[0],coord[1],coord[2]) == 0) {
-      rsq = 1.1;
-      while (rsq > 1.0) {
-        rx = 2*random_equal->uniform() - 1.0;
-        ry = 2*random_equal->uniform() - 1.0;
-        rz = 2*random_equal->uniform() - 1.0;
-        rsq = rx*rx + ry*ry + rz*rz;
-      }
-      coord[0] = com[0] + displace*rx;
-      coord[1] = com[1] + displace*ry;
-      coord[2] = com[2] + displace*rz;
-    }
-    com_displace[0] = displace*rx;
-    com_displace[1] = displace*ry;
-    com_displace[2] = displace*rz;
-  }
-
-  for (int i = 0; i < atom->nlocal; i++) {
-    if (atom->molecule[i] == translation_molecule) {
-      x[i][0] += com_displace[0];
-      x[i][1] += com_displace[1];
-      x[i][2] += com_displace[2];
-      if (!domain->inside_nonperiodic(x[i]))
-        error->one(FLERR,"Fix vmmc put atom outside box");
-    }
-  }
-
-  double energy_after = energy_full();
-
-  if (energy_after < MAXENERGYTEST &&
-      random_equal->uniform() <
-      exp(beta*(energy_before - energy_after))) {
-    ntranslation_successes += 1.0;
-    energy_stored = energy_after;
-  } else {
-    energy_stored = energy_before;
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (atom->molecule[i] == translation_molecule) {
-        x[i][0] -= com_displace[0];
-        x[i][1] -= com_displace[1];
-        x[i][2] -= com_displace[2];
-      }
-    }
-  }
-  update_gas_atoms_list();
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_molecule_rotation_full()
-{
-  nrotation_attempts += 1.0;
-
-  if (ngas == 0) return;
-
-  tagint rotation_molecule = pick_random_gas_molecule();
-  if (rotation_molecule == -1) return;
-
-  double energy_before = energy_stored;
-
-  int *mask = atom->mask;
-  int nmolcoords = 0;
-  for (int i = 0; i < atom->nlocal; i++) {
-    if (atom->molecule[i] == rotation_molecule) {
-      mask[i] |= molecule_group_bit;
-      nmolcoords++;
-    } else {
-      mask[i] &= molecule_group_inversebit;
-    }
-  }
-
-  if (nmolcoords > nmaxmolatoms)
-    grow_molecule_arrays(nmolcoords);
-
-  double com[3];
-  com[0] = com[1] = com[2] = 0.0;
-  group->xcm(molecule_group,gas_mass,com);
-
-  // generate point in unit cube
-  // then restrict to unit sphere
-
-  double r[3],rotmat[3][3],quat[4];
-  double rsq = 1.1;
-  while (rsq > 1.0) {
-    r[0] = 2.0*random_equal->uniform() - 1.0;
-    r[1] = 2.0*random_equal->uniform() - 1.0;
-    r[2] = 2.0*random_equal->uniform() - 1.0;
-    rsq = MathExtra::dot3(r, r);
-  }
-
-  double theta = random_equal->uniform() * max_rotation_angle;
-  MathExtra::norm3(r);
-  MathExtra::axisangle_to_quat(r,theta,quat);
-  MathExtra::quat_to_mat(quat,rotmat);
-
-  double **x = atom->x;
-  imageint *image = atom->image;
-
-  int n = 0;
-  for (int i = 0; i < atom->nlocal; i++) {
-    if (mask[i] & molecule_group_bit) {
-      molcoords[n][0] = x[i][0];
-      molcoords[n][1] = x[i][1];
-      molcoords[n][2] = x[i][2];
-      molimage[n] = image[i];
-      double xtmp[3];
-      domain->unmap(x[i],image[i],xtmp);
-      xtmp[0] -= com[0];
-      xtmp[1] -= com[1];
-      xtmp[2] -= com[2];
-      MathExtra::matvec(rotmat,xtmp,x[i]);
-      x[i][0] += com[0];
-      x[i][1] += com[1];
-      x[i][2] += com[2];
-      image[i] = imagezero;
-      domain->remap(x[i],image[i]);
-      if (!domain->inside(x[i]))
-        error->one(FLERR,"Fix vmmc put atom outside box");
-      n++;
-    }
-  }
-
-  double energy_after = energy_full();
-
-  if (energy_after < MAXENERGYTEST &&
-      random_equal->uniform() <
-      exp(beta*(energy_before - energy_after))) {
-    nrotation_successes += 1.0;
-    energy_stored = energy_after;
-  } else {
-    energy_stored = energy_before;
-    int n = 0;
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (mask[i] & molecule_group_bit) {
-        x[i][0] = molcoords[n][0];
-        x[i][1] = molcoords[n][1];
-        x[i][2] = molcoords[n][2];
-        image[i] = molimage[n];
-        n++;
-      }
-    }
-  }
-  update_gas_atoms_list();
-}
-
-/* ----------------------------------------------------------------------
    compute particle's interaction energy with the rest of the system by
    looping over all atoms in the sub-domain including ghosts.
 ------------------------------------------------------------------------- */
@@ -1316,7 +828,6 @@ double FixVMMC::energy(int i, int itype, tagint imolecule, double *coord)
 
   double **x = atom->x;
   int *type = atom->type;
-  tagint *molecule = atom->molecule;
   int nall = atom->nlocal + atom->nghost;
   pair = force->pair;
   cutsq = force->pair->cutsq;
@@ -1352,31 +863,11 @@ double FixVMMC::energy(int i, int itype, tagint imolecule, double *coord)
 }
 
 /* ----------------------------------------------------------------------
-   compute the energy of the given gas molecule in its current position
-   sum across all procs that own atoms of the given molecule
-------------------------------------------------------------------------- */
-
-double FixVMMC::molecule_energy(tagint gas_molecule_id)
-{
-  double mol_energy = 0.0;
-  for (int i = 0; i < atom->nlocal; i++)
-    if (atom->molecule[i] == gas_molecule_id) {
-      mol_energy += energy(i,atom->type[i],gas_molecule_id,atom->x[i]);
-    }
-
-  double mol_energy_sum = 0.0;
-  MPI_Allreduce(&mol_energy,&mol_energy_sum,1,MPI_DOUBLE,MPI_SUM,world);
-
-  return mol_energy_sum;
-}
-
-/* ----------------------------------------------------------------------
    compute system potential energy
 ------------------------------------------------------------------------- */
 
 double FixVMMC::energy_full()
 {
-  int imolecule;
 
   if (triclinic) domain->x2lamda(atom->nlocal);
   domain->pbc();
@@ -1397,7 +888,6 @@ double FixVMMC::energy_full()
     int overlaptest = 0;
     double delx,dely,delz,rsq;
     double **x = atom->x;
-    tagint *molecule = atom->molecule;
     int nall = atom->nlocal + atom->nghost;
     for (int i = 0; i < atom->nlocal; i++) {
       for (int j = i+1; j < nall; j++) {
@@ -1517,7 +1007,6 @@ void FixVMMC::update_gas_atoms_list()
 {
   int nlocal = atom->nlocal;
   int *mask = atom->mask;
-  tagint *molecule = atom->molecule;
   double **x = atom->x;
 
   if (atom->nmax > vmmc_nmax) {
@@ -1627,14 +1116,6 @@ void FixVMMC::restart(char *buf)
   if (ntimestep_restart != update->ntimestep)
     error->all(FLERR,"Must not reset timestep when restarting fix vmmc");
 }
-
-void FixVMMC::grow_molecule_arrays(int nmolatoms) {
-    nmaxmolatoms = nmolatoms;
-    molcoords = memory->grow(molcoords,nmaxmolatoms,3,"vmmc:molcoords");
-    molq = memory->grow(molq,nmaxmolatoms,"vmmc:molq");
-    molimage = memory->grow(molimage,nmaxmolatoms,"vmmc:molimage");
-}
-
 
 /* ----------------------------------------------------------------------
    extract variable which stores whether MC is active or not

--- a/src/MC/fix_vmmc.h
+++ b/src/MC/fix_vmmc.h
@@ -38,21 +38,18 @@ class FixVMMC : public Fix {
   void *extract(const char *, int &) override;
 
  private:
-  int molecule_group, molecule_group_bit;
-  int molecule_group_inversebit;
   int exclusion_group, exclusion_group_bit;
   int nvmmc_type, nevery, seed;
-  int ncycles, nexchanges, nmcmoves;
+  int ncycles, nmcmoves;
   double patomtrans, pmctot;
   int ngas;                // # of gas atoms on all procs
   int ngas_local;          // # of gas atoms on this proc
   int ngas_before;         // # of gas atoms on procs < this proc
-  int exchmode;            // exchange ATOM or MOLECULE
-  int movemode;            // move ATOM or MOLECULE
+  int exchmode;            // exchange ATOM, MOLECULE not supported
+  int movemode;            // move ATOM, MOLECULE not supported
   class Region *region;    // vmmc region
   char *idregion;          // vmmc region id
   bool pressure_flag;      // true if user specified reservoir pressure
-  bool charge_flag;        // true if user specified atomic charge
   bool full_flag;          // true if doing full system energy calculations
 
   int groupbitall;            // group bitmask for inserted atoms
@@ -64,8 +61,6 @@ class FixVMMC : public Fix {
   int *grouptypes;            // list of type-based group types
   double ntranslation_attempts;
   double ntranslation_successes;
-  double nrotation_attempts;
-  double nrotation_successes;
 
   int mc_active;              // 1 during MC trials, otherwise 0
 
@@ -74,11 +69,10 @@ class FixVMMC : public Fix {
   double gas_mass;
   double reservoir_temperature;
   double tfac_insert;
-  double chemical_potential;
   double displace;
   double max_rotation_angle;
-  double beta, zz, sigma, volume;
-  double pressure, fugacity_coeff, charge;
+  double beta;
+  double volume, pressure;
   double xlo, xhi, ylo, yhi, zlo, zhi;
   double region_xlo, region_xhi, region_ylo, region_yhi, region_zlo, region_zhi;
   double region_volume;
@@ -117,7 +111,6 @@ class FixVMMC : public Fix {
 
   int pick_random_gas_atom();
   tagint pick_random_gas_molecule();
-  void toggle_intramolecular(int);
   void update_gas_atoms_list();
 
 };

--- a/src/MC/fix_vmmc.h
+++ b/src/MC/fix_vmmc.h
@@ -43,7 +43,7 @@ class FixVMMC : public Fix {
   int exclusion_group, exclusion_group_bit;
   int nvmmc_type, nevery, seed;
   int ncycles, nexchanges, nmcmoves;
-  double patomtrans, pmoltrans, pmolrotate, pmctot;
+  double patomtrans, pmctot;
   int ngas;                // # of gas atoms on all procs
   int ngas_local;          // # of gas atoms on this proc
   int ngas_before;         // # of gas atoms on procs < this proc
@@ -54,9 +54,6 @@ class FixVMMC : public Fix {
   bool pressure_flag;      // true if user specified reservoir pressure
   bool charge_flag;        // true if user specified atomic charge
   bool full_flag;          // true if doing full system energy calculations
-
-  int natoms_per_molecule;    // number of atoms in each inserted molecule
-  int nmaxmolatoms;           // number of atoms allocated for molecule arrays
 
   int groupbitall;            // group bitmask for inserted atoms
   int ngroups;                // number of group-ids for inserted atoms
@@ -89,9 +86,6 @@ class FixVMMC : public Fix {
   double *sublo, *subhi;
   int *local_gas_list;
   double **cutsq;
-  double **molcoords;
-  double *molq;
-  imageint *molimage;
   imageint imagezero;
   double overlap_cutoffsq;    // square distance cutoff for overlap
   int overlap_flag;
@@ -107,11 +101,6 @@ class FixVMMC : public Fix {
 
   class Atom *model_atom;
 
-  class Molecule **onemols;
-  int imol, nmol;
-  class Fix *fixrigid, *fixshake;
-  int rigidflag, shakeflag;
-  char *idrigid, *idshake;
   int triclinic;    // 0 = orthog box, 1 = triclinic
 
   class Compute *c_pe;
@@ -121,22 +110,16 @@ class FixVMMC : public Fix {
   void options(int, char **);
 
   void attempt_atomic_translation();
-  void attempt_molecule_translation();
-  void attempt_molecule_rotation();
   void attempt_atomic_translation_full();
-  void attempt_molecule_translation_full();
-  void attempt_molecule_rotation_full();
 
   double energy(int, int, tagint, double *);
   double energy_full();
-  double molecule_energy(tagint);
 
   int pick_random_gas_atom();
   tagint pick_random_gas_molecule();
   void toggle_intramolecular(int);
   void update_gas_atoms_list();
 
-  void grow_molecule_arrays(int);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/MC/fix_vmmc.h
+++ b/src/MC/fix_vmmc.h
@@ -69,10 +69,6 @@ class FixVMMC : public Fix {
   double ntranslation_successes;
   double nrotation_attempts;
   double nrotation_successes;
-  double ndeletion_attempts;
-  double ndeletion_successes;
-  double ninsertion_attempts;
-  double ninsertion_successes;
 
   int mc_active;              // 1 during MC trials, otherwise 0
 
@@ -125,19 +121,11 @@ class FixVMMC : public Fix {
   void options(int, char **);
 
   void attempt_atomic_translation();
-  void attempt_atomic_deletion();
-  void attempt_atomic_insertion();
   void attempt_molecule_translation();
   void attempt_molecule_rotation();
-  void attempt_molecule_deletion();
-  void attempt_molecule_insertion();
   void attempt_atomic_translation_full();
-  void attempt_atomic_deletion_full();
-  void attempt_atomic_insertion_full();
   void attempt_molecule_translation_full();
   void attempt_molecule_rotation_full();
-  void attempt_molecule_deletion_full();
-  void attempt_molecule_insertion_full();
 
   double energy(int, int, tagint, double *);
   double energy_full();


### PR DESCRIPTION
The FixVMMC class is trimmed back retaining the basic necessary functionality for SPMC but without options for atom and molecule deletion and insertion. 

The input file has been slightly modified to have a smaller number of arguments in the fix command reflecting this change. More specifically we have now a command `fix ID group-ID vmmc N M type seed T displace keyword values` where `keyword values` has been also reduced.

An example input file is attached.
[ljbench.in.txt](https://github.com/user-attachments/files/20698597/ljbench.in.txt)

