### PR TITLE
New initialisation of VMMC object in pre_echange() routine

### DIFF
--- a/src/MC/fix_vmmc.cpp
+++ b/src/MC/fix_vmmc.cpp
@@ -71,11 +71,11 @@ enum { NONE, MOVEATOM };    // movemode
 /* ---------------------------------------------------------------------- */
 
 FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
-    Fix(lmp, narg, arg), region(nullptr), idregion(nullptr), full_flag(false),
-    groupstrings(nullptr), grouptypestrings(nullptr), grouptypebits(nullptr), grouptypes(nullptr),
-    local_gas_list(nullptr), random_equal(nullptr), random_unequal(nullptr)
+    Fix(lmp, narg, arg), region(nullptr), idregion(nullptr), groupstrings(nullptr),
+    grouptypestrings(nullptr), grouptypebits(nullptr), grouptypes(nullptr),
+    random_equal(nullptr), random_unequal(nullptr)
 {
-  if (narg < 9) utils::missing_cmd_args(FLERR, "fix vmmc", error);
+  if (narg < 10) utils::missing_cmd_args(FLERR, "fix vmmc", error);
 
   if (atom->molecular == Atom::TEMPLATE)
     error->all(FLERR,"Fix vmmc does not (yet) work with atom_style template");
@@ -91,27 +91,27 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
 
   ngroups = 0;
   ngrouptypes = 0;
-  triclinic = domain->triclinic;
 
   // required args
 
   nevery = utils::inumeric(FLERR, arg[3], false, lmp);
-  nmcmoves = utils::inumeric(FLERR, arg[4], false, lmp);
+  nvmmcmoves = utils::inumeric(FLERR, arg[4], false, lmp);
   nvmmc_type = utils::expand_type_int(FLERR, arg[5], Atom::ATOM, lmp);
   seed = utils::inumeric(FLERR, arg[6], false, lmp);
   reservoir_temperature = utils::numeric(FLERR, arg[7], false, lmp);
-  displace = utils::numeric(FLERR, arg[8], false, lmp);
+  max_translate = utils::numeric(FLERR, arg[8], false, lmp);
+  max_rotate = utils::numeric(FLERR, arg[9], false, lmp);
 
   if (nevery <= 0) error->all(FLERR, "Illegal fix vmmc command");
-  if (nmcmoves < 0) error->all(FLERR, "Illegal fix vmmc command");
+  if (nvmmcmoves < 0) error->all(FLERR, "Illegal fix vmmc command");
   if (seed <= 0) error->all(FLERR, "Illegal fix vmmc command");
   if (reservoir_temperature < 0.0)
     error->all(FLERR, "Illegal fix vmmc command");
-  if (displace < 0.0) error->all(FLERR, "Illegal fix vmmc command");
+  if (max_translate < 0.0) error->all(FLERR, "Illegal fix vmmc command");
 
   // read options from end of input line
 
-  options(narg-9,&arg[9]);
+  options(narg-10,&arg[10]);
 
   // random number generator, same for all procs
 
@@ -158,23 +158,16 @@ FixVMMC::FixVMMC(LAMMPS *lmp, int narg, char **arg) :
 
   // compute the number of MC cycles that occur nevery timesteps
 
-  ncycles = nmcmoves;
+  ncycles = nvmmcmoves;
 
   // set up reneighboring
 
   force_reneighbor = 1;
   next_reneighbor = update->ntimestep + 1;
 
-  // zero out counters
-
   mc_active = 0;
 
-  ntranslation_attempts = 0.0;
-  ntranslation_successes = 0.0;
-
   vmmc_nmax = 0;
-  local_gas_list = nullptr;
-
   vmmc = nullptr;
 
 }
@@ -192,14 +185,12 @@ void FixVMMC::options(int narg, char **arg)
   movemode = NONE;
   patomtrans = 0.0;
   pmctot = 0.0;
-  max_rotation_angle = 10*MY_PI/180;
   region_volume = 0;
   max_region_attempts = 1000;
   exclusion_group = 0;
   exclusion_group_bit = 0;
   pressure_flag = false;
   pressure = 0.0;
-  full_flag = false;
   ngroups = 0;
   int ngroupsmax = 0;
   groupstrings = nullptr;
@@ -208,12 +199,9 @@ void FixVMMC::options(int narg, char **arg)
   grouptypestrings = nullptr;
   grouptypes = nullptr;
   grouptypebits = nullptr;
-  energy_intra = 0.0;
   tfac_insert = 1.0;
   overlap_cutoffsq = 0.0;
   overlap_flag = 0;
-  min_ngas = -1;
-  max_ngas = INT_MAX;
 
   int iarg = 0;
   while (iarg < narg) {
@@ -232,19 +220,11 @@ void FixVMMC::options(int narg, char **arg)
       if (!region) error->all(FLERR,"Region {} for fix vmmc does not exist",arg[iarg+1]);
       idregion = utils::strdup(arg[iarg+1]);
       iarg += 2;
-    } else if (strcmp(arg[iarg],"maxangle") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      max_rotation_angle = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      max_rotation_angle *= MY_PI/180;
-      iarg += 2;
     } else if (strcmp(arg[iarg],"pressure") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
       pressure = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       pressure_flag = true;
       iarg += 2;
-    }  else if (strcmp(arg[iarg],"full_energy") == 0) {
-      full_flag = true;
-      iarg += 1;
     } else if (strcmp(arg[iarg],"group") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
       if (ngroups >= ngroupsmax) {
@@ -272,10 +252,6 @@ void FixVMMC::options(int narg, char **arg)
       grouptypestrings[ngrouptypes] = utils::strdup(arg[iarg+2]);
       ngrouptypes++;
       iarg += 3;
-    } else if (strcmp(arg[iarg],"intra_energy") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      energy_intra = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      iarg += 2;
     } else if (strcmp(arg[iarg],"tfac_insert") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
       tfac_insert = utils::numeric(FLERR,arg[iarg+1],false,lmp);
@@ -285,14 +261,6 @@ void FixVMMC::options(int narg, char **arg)
       double rtmp = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       overlap_cutoffsq = rtmp*rtmp;
       overlap_flag = 1;
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"min") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      min_ngas = utils::numeric(FLERR,arg[iarg+1],false,lmp);
-      iarg += 2;
-    } else if (strcmp(arg[iarg],"max") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal fix vmmc command");
-      max_ngas = utils::numeric(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
     } else error->all(FLERR,"Illegal fix vmmc command");
   }
@@ -305,8 +273,6 @@ FixVMMC::~FixVMMC()
   delete[] idregion;
   delete random_equal;
   delete random_unequal;
-
-  memory->destroy(local_gas_list);
 
   if (ngroups > 0) {
     for (int igroup = 0; igroup < ngroups; igroup++)
@@ -338,10 +304,6 @@ FixVMMC::~FixVMMC()
     }
   }
 
-  if (full_flag && group && neighbor) {
-    int igroupall = group->find("all");
-    neighbor->exclusion_group_group_delete(exclusion_group,igroupall);
-  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -360,8 +322,6 @@ void FixVMMC::init()
   if (!atom->mass) error->all(FLERR, "Fix vmmc requires per atom type masses");
   if (atom->rmass_flag && (comm->me == 0))
     error->warning(FLERR, "Fix vmmc will use per atom type masses for velocity initialization");
-
-  triclinic = domain->triclinic;
 
   // set index and check validity of region
 
@@ -383,23 +343,15 @@ void FixVMMC::init()
     region_zlo = region->extent_zlo;
     region_zhi = region->extent_zhi;
 
-    if (triclinic) {
-      if ((region_xlo < domain->boxlo_bound[0]) || (region_xhi > domain->boxhi_bound[0]) ||
-          (region_ylo < domain->boxlo_bound[1]) || (region_yhi > domain->boxhi_bound[1]) ||
-          (region_zlo < domain->boxlo_bound[2]) || (region_zhi > domain->boxhi_bound[2])) {
-        error->all(FLERR,"Fix vmmc region extends outside simulation box");
-      }
-    } else {
-      if ((region_xlo < domain->boxlo[0]) || (region_xhi > domain->boxhi[0]) ||
-          (region_ylo < domain->boxlo[1]) || (region_yhi > domain->boxhi[1]) ||
-          (region_zlo < domain->boxlo[2]) || (region_zhi > domain->boxhi[2]))
-        error->all(FLERR,"Fix vmmc region extends outside simulation box");
-    }
-  }
+    if ((region_xlo < domain->boxlo[0]) || (region_xhi > domain->boxhi[0]) ||
+        (region_ylo < domain->boxlo[1]) || (region_yhi > domain->boxhi[1]) ||
+        (region_zlo < domain->boxlo[2]) || (region_zhi > domain->boxhi[2]))
+      error->all(FLERR,"Fix vmmc region extends outside simulation box");
+   }
 
   // set probabilities for MC moves
 
-  if (nmcmoves > 0) {
+  if (nvmmcmoves > 0) {
     movemode = MOVEATOM;
     if (pmctot == 0.0) {
         patomtrans = 1.0;
@@ -409,52 +361,8 @@ void FixVMMC::init()
     }
   } else movemode = NONE;
 
-  // decide whether to switch to the full_energy option
-
-  if (!full_flag) {
-    if ((force->kspace) ||
-        (force->pair == nullptr) ||
-        (force->pair->single_enable == 0) ||
-        (force->pair_match("^hybrid",0)) ||
-        (force->pair_match("^eam",0)) ||
-        (force->pair->tail_flag)) {
-      full_flag = true;
-      if (comm->me == 0)
-        error->warning(FLERR,"Fix vmmc using full_energy option");
-    }
-  }
-
-  if (full_flag) c_pe = modify->compute[modify->find_compute("thermo_pe")];
-
   if (domain->dimension == 2)
     error->all(FLERR,"Cannot use fix vmmc in a 2d simulation");
-
-  // create a new group for interaction exclusions
-  // used for attempted atom or molecule deletions
-  // skip if already exists from previous init()
-
-  if (full_flag && !exclusion_group_bit) {
-
-    // create unique group name for atoms to be excluded
-
-    auto group_id = std::string("FixVMMC:vmmc_exclusion_group:") + id;
-    group->assign(group_id + " subtract all all");
-    exclusion_group = group->find(group_id);
-    if (exclusion_group == -1)
-      error->all(FLERR,"Could not find fix vmmc exclusion group ID");
-    exclusion_group_bit = group->bitmask[exclusion_group];
-
-    // neighbor list exclusion setup
-    // turn off interactions between group all and the exclusion group
-
-    neighbor->modify_params(fmt::format("exclude group {} all",group_id));
-  }
-
-  // get the gas mass
-  gas_mass = atom->mass[nvmmc_type];
-
-  if (gas_mass <= 0.0)
-    error->all(FLERR,"Illegal fix vmmc gas mass <= 0");
 
   // check that no deletable atoms are in atom->firstgroup
   // deleting such an atom would not leave firstgroup atoms first
@@ -510,6 +418,22 @@ void FixVMMC::init()
     }
   }
 
+}
+
+/* ----------------------------------------------------------------------
+   attempt Virtual Move Monte Carlo translations and rotations
+   done before exchange, borders, reneighbor
+   so that ghost atoms and neighbor lists will be correct
+------------------------------------------------------------------------- */
+
+void FixVMMC::pre_exchange()
+{
+  // just return if should not be called on this timestep
+
+  if (next_reneighbor != update->ntimestep) return;
+
+  mc_active = 1;
+
   // initialise the VMMC callback functions
   using namespace std::placeholders;
   vmmc::CallbackFunctions callbacks;
@@ -546,370 +470,17 @@ void FixVMMC::init()
 
   // initialise the VMMC object
   vmmc = new VMMC(atom->natoms, domain->dimension, coordinates, orientations,
-      0.15, 0.2, 0.5, 0.5, maxInteractions, &boxSize[0], isIsotropic, true, callbacks);
+      max_translate, max_rotate, 0.5, 0.5, maxInteractions, &boxSize[0], isIsotropic, true, callbacks);
 
-}
+  // perform nvmmcmoves VMMC trial moves
+  vmmc->step(nvmmcmoves);
 
-/* ----------------------------------------------------------------------
-   attempt Monte Carlo translations
-   done before exchange, borders, reneighbor
-   so that ghost atoms and neighbor lists will be correct
-------------------------------------------------------------------------- */
-
-void FixVMMC::pre_exchange()
-{
-  // just return if should not be called on this timestep
-
-  if (next_reneighbor != update->ntimestep) return;
-
-  vmmc->step();
-
-  mc_active = 1;
-
-  xlo = domain->boxlo[0];
-  xhi = domain->boxhi[0];
-  ylo = domain->boxlo[1];
-  yhi = domain->boxhi[1];
-  zlo = domain->boxlo[2];
-  zhi = domain->boxhi[2];
-  if (triclinic) {
-    sublo = domain->sublo_lamda;
-    subhi = domain->subhi_lamda;
-  } else {
-    sublo = domain->sublo;
-    subhi = domain->subhi;
-  }
-
-  if (region) volume = region_volume;
-  else volume = domain->xprd * domain->yprd * domain->zprd;
-
-  if (triclinic) domain->x2lamda(atom->nlocal);
-  domain->pbc();
-  comm->exchange();
-  atom->nghost = 0;
-  comm->borders();
-  if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-  update_gas_atoms_list();
-
-  if (full_flag) {
-    energy_stored = energy_full();
-    if (overlap_flag && energy_stored > MAXENERGYTEST)
-        error->warning(FLERR,"Energy of old configuration in "
-                       "fix vmmc is > MAXENERGYTEST.");
-
-    for (int i = 0; i < ncycles; i++) {
-      int ixm = static_cast<int>(random_equal->uniform()*ncycles) + 1;
-      if (ixm <= nmcmoves) {
-        double xmcmove = random_equal->uniform();
-        if (xmcmove < patomtrans) attempt_atomic_translation_full();
-      }
-    }
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    domain->pbc();
-    comm->exchange();
-    atom->nghost = 0;
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-
-  } else {
-
-    for (int i = 0; i < ncycles; i++) {
-      int ixm = static_cast<int>(random_equal->uniform()*ncycles) + 1;
-      if (ixm <= nmcmoves) {
-        double xmcmove = random_equal->uniform();
-        if (xmcmove < patomtrans) attempt_atomic_translation();
-      }
-    }
-  }
+  delete vmmc;
 
   next_reneighbor = update->ntimestep + nevery;
 
   mc_active = 0;
-}
 
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_atomic_translation()
-{
-  ntranslation_attempts += 1.0;
-
-  if (ngas == 0) return;
-
-  int i = pick_random_gas_atom();
-
-  int success = 0;
-  if (i >= 0) {
-    double **x = atom->x;
-    double energy_before = energy(i,nvmmc_type,-1,x[i]);
-    if (overlap_flag && energy_before > MAXENERGYTEST)
-        error->warning(FLERR,"Energy of old configuration in fix vmmc is > MAXENERGYTEST.");
-    double rsq = 1.1;
-    double rx,ry,rz;
-    rx = ry = rz = 0.0;
-    double coord[3];
-    while (rsq > 1.0) {
-      rx = 2*random_unequal->uniform() - 1.0;
-      ry = 2*random_unequal->uniform() - 1.0;
-      rz = 2*random_unequal->uniform() - 1.0;
-      rsq = rx*rx + ry*ry + rz*rz;
-    }
-    coord[0] = x[i][0] + displace*rx;
-    coord[1] = x[i][1] + displace*ry;
-    coord[2] = x[i][2] + displace*rz;
-    if (region) {
-      while (region->match(coord[0],coord[1],coord[2]) == 0) {
-        rsq = 1.1;
-        while (rsq > 1.0) {
-          rx = 2*random_unequal->uniform() - 1.0;
-          ry = 2*random_unequal->uniform() - 1.0;
-          rz = 2*random_unequal->uniform() - 1.0;
-          rsq = rx*rx + ry*ry + rz*rz;
-        }
-        coord[0] = x[i][0] + displace*rx;
-        coord[1] = x[i][1] + displace*ry;
-        coord[2] = x[i][2] + displace*rz;
-      }
-    }
-    if (!domain->inside_nonperiodic(coord))
-      error->one(FLERR,"Fix vmmc put atom outside box");
-
-    double energy_after = energy(i,nvmmc_type,-1,coord);
-
-    if (energy_after < MAXENERGYTEST &&
-        random_unequal->uniform() <
-        exp(beta*(energy_before - energy_after))) {
-      x[i][0] = coord[0];
-      x[i][1] = coord[1];
-      x[i][2] = coord[2];
-      success = 1;
-    }
-  }
-
-  int success_all = 0;
-  MPI_Allreduce(&success,&success_all,1,MPI_INT,MPI_MAX,world);
-
-  if (success_all) {
-    if (triclinic) domain->x2lamda(atom->nlocal);
-    domain->pbc();
-    comm->exchange();
-    atom->nghost = 0;
-    comm->borders();
-    if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-    update_gas_atoms_list();
-    ntranslation_successes += 1.0;
-  }
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-void FixVMMC::attempt_atomic_translation_full()
-{
-  ntranslation_attempts += 1.0;
-
-  if (ngas == 0) return;
-
-  double energy_before = energy_stored;
-
-  int i = pick_random_gas_atom();
-
-  double **x = atom->x;
-  double xtmp[3];
-
-  xtmp[0] = xtmp[1] = xtmp[2] = 0.0;
-
-  tagint tmptag = -1;
-
-  if (i >= 0) {
-
-    double rsq = 1.1;
-    double rx,ry,rz;
-    rx = ry = rz = 0.0;
-    double coord[3];
-    while (rsq > 1.0) {
-      rx = 2*random_unequal->uniform() - 1.0;
-      ry = 2*random_unequal->uniform() - 1.0;
-      rz = 2*random_unequal->uniform() - 1.0;
-      rsq = rx*rx + ry*ry + rz*rz;
-    }
-    coord[0] = x[i][0] + displace*rx;
-    coord[1] = x[i][1] + displace*ry;
-    coord[2] = x[i][2] + displace*rz;
-    if (region) {
-      while (region->match(coord[0],coord[1],coord[2]) == 0) {
-        rsq = 1.1;
-        while (rsq > 1.0) {
-          rx = 2*random_unequal->uniform() - 1.0;
-          ry = 2*random_unequal->uniform() - 1.0;
-          rz = 2*random_unequal->uniform() - 1.0;
-          rsq = rx*rx + ry*ry + rz*rz;
-        }
-        coord[0] = x[i][0] + displace*rx;
-        coord[1] = x[i][1] + displace*ry;
-        coord[2] = x[i][2] + displace*rz;
-      }
-    }
-    if (!domain->inside_nonperiodic(coord))
-      error->one(FLERR,"Fix vmmc put atom outside box");
-    xtmp[0] = x[i][0];
-    xtmp[1] = x[i][1];
-    xtmp[2] = x[i][2];
-    x[i][0] = coord[0];
-    x[i][1] = coord[1];
-    x[i][2] = coord[2];
-
-    tmptag = atom->tag[i];
-  }
-
-  double energy_after = energy_full();
-
-  if (energy_after < MAXENERGYTEST &&
-      random_equal->uniform() <
-      exp(beta*(energy_before - energy_after))) {
-    energy_stored = energy_after;
-    ntranslation_successes += 1.0;
-  } else {
-
-    tagint tmptag_all;
-    MPI_Allreduce(&tmptag,&tmptag_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
-
-    double xtmp_all[3];
-    MPI_Allreduce(&xtmp,&xtmp_all,3,MPI_DOUBLE,MPI_SUM,world);
-
-    for (int i = 0; i < atom->nlocal; i++) {
-      if (tmptag_all == atom->tag[i]) {
-        x[i][0] = xtmp_all[0];
-        x[i][1] = xtmp_all[1];
-        x[i][2] = xtmp_all[2];
-      }
-    }
-    energy_stored = energy_before;
-  }
-  update_gas_atoms_list();
-}
-
-/* ----------------------------------------------------------------------
-   compute particle's interaction energy with the rest of the system by
-   looping over all atoms in the sub-domain including ghosts.
-------------------------------------------------------------------------- */
-
-double FixVMMC::energy(int i, int itype, tagint imolecule, double *coord)
-{
-  double delx,dely,delz,rsq;
-
-  double **x = atom->x;
-  int *type = atom->type;
-  int nall = atom->nlocal + atom->nghost;
-  pair = force->pair;
-  cutsq = force->pair->cutsq;
-
-  double fpair = 0.0;
-  double factor_coul = 1.0;
-  double factor_lj = 1.0;
-
-  double total_energy = 0.0;
-
-  for (int j = 0; j < nall; j++) {
-
-    if (i == j) continue;
-
-    delx = coord[0] - x[j][0];
-    dely = coord[1] - x[j][1];
-    delz = coord[2] - x[j][2];
-    rsq = delx*delx + dely*dely + delz*delz;
-    int jtype = type[j];
-
-    // if overlap check requested, if overlap,
-    // return signal value for energy
-
-    if (overlap_flag && rsq < overlap_cutoffsq)
-      return MAXENERGYSIGNAL;
-
-    if (rsq < cutsq[itype][jtype])
-      total_energy +=
-        pair->single(i,j,itype,jtype,rsq,factor_coul,factor_lj,fpair);
-  }
-
-  return total_energy;
-}
-
-/* ----------------------------------------------------------------------
-   compute system potential energy
-------------------------------------------------------------------------- */
-
-double FixVMMC::energy_full()
-{
-
-  if (triclinic) domain->x2lamda(atom->nlocal);
-  domain->pbc();
-  comm->exchange();
-  atom->nghost = 0;
-  comm->borders();
-  if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
-  if (modify->n_pre_neighbor) modify->pre_neighbor();
-  neighbor->build(1);
-  int eflag = 1;
-  int vflag = 0;
-
-  // if overlap check requested, if overlap,
-  // return signal value for energy
-
-  if (overlap_flag) {
-    int overlaptestall;
-    int overlaptest = 0;
-    double delx,dely,delz,rsq;
-    double **x = atom->x;
-    int nall = atom->nlocal + atom->nghost;
-    for (int i = 0; i < atom->nlocal; i++) {
-      for (int j = i+1; j < nall; j++) {
-
-        delx = x[i][0] - x[j][0];
-        dely = x[i][1] - x[j][1];
-        delz = x[i][2] - x[j][2];
-        rsq = delx*delx + dely*dely + delz*delz;
-
-        if (rsq < overlap_cutoffsq) {
-          overlaptest = 1;
-          break;
-        }
-      }
-      if (overlaptest) break;
-    }
-    MPI_Allreduce(&overlaptest, &overlaptestall, 1, MPI_INT, MPI_MAX, world);
-    if (overlaptestall) return MAXENERGYSIGNAL;
-  }
-
-  // clear forces so they don't accumulate over multiple
-  // calls within fix vmmc timestep
-
-  size_t nbytes = sizeof(double) * (atom->nlocal + atom->nghost);
-  if (nbytes) memset(&atom->f[0][0],0,3*nbytes);
-
-  if (modify->n_pre_force) modify->pre_force(vflag);
-
-  if (force->pair) force->pair->compute(eflag,vflag);
-
-  if (atom->molecular != Atom::ATOMIC) {
-    if (force->bond) force->bond->compute(eflag,vflag);
-    if (force->angle) force->angle->compute(eflag,vflag);
-    if (force->dihedral) force->dihedral->compute(eflag,vflag);
-    if (force->improper) force->improper->compute(eflag,vflag);
-  }
-
-  if (force->kspace) force->kspace->compute(eflag,vflag);
-
-  if (modify->n_post_force_any) modify->post_force(vflag);
-
-  // NOTE: all fixes with energy_global_flag set and which
-  //   operate at pre_force() or post_force()
-  //   and which user has enabled via fix_modify energy yes,
-  //   will contribute to total MC energy via pe->compute_scalar()
-
-  update->eflag_global = update->ntimestep;
-  double total_energy = c_pe->compute_scalar();
-
-  return total_energy;
 }
 
 /* ----------------------------------------------------------------------
@@ -957,99 +528,11 @@ unsigned int FixVMMC::interactions_vmmc(
 void FixVMMC::post_move_vmmc(
     unsigned int index, const double* pos, const double* orient)
 {
+  atom->x[index][0] = pos[0];
+  atom->x[index][1] = pos[1];
+  atom->x[index][2] = pos[2];
+
   return;
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-int FixVMMC::pick_random_gas_atom()
-{
-  int i = -1;
-  int iwhichglobal = static_cast<int> (ngas*random_equal->uniform());
-  if ((iwhichglobal >= ngas_before) &&
-      (iwhichglobal < ngas_before + ngas_local)) {
-    int iwhichlocal = iwhichglobal - ngas_before;
-    i = local_gas_list[iwhichlocal];
-  }
-
-  return i;
-}
-
-/* ----------------------------------------------------------------------
-------------------------------------------------------------------------- */
-
-tagint FixVMMC::pick_random_gas_molecule()
-{
-  int iwhichglobal = static_cast<int> (ngas*random_equal->uniform());
-  tagint gas_molecule_id = 0;
-  if ((iwhichglobal >= ngas_before) &&
-      (iwhichglobal < ngas_before + ngas_local)) {
-    int iwhichlocal = iwhichglobal - ngas_before;
-    int i = local_gas_list[iwhichlocal];
-    gas_molecule_id = atom->molecule[i];
-  }
-
-  tagint gas_molecule_id_all = 0;
-  MPI_Allreduce(&gas_molecule_id,&gas_molecule_id_all,1,
-                MPI_LMP_TAGINT,MPI_MAX,world);
-
-  return gas_molecule_id_all;
-}
-
-/* ----------------------------------------------------------------------
-   update the list of gas atoms
-------------------------------------------------------------------------- */
-
-void FixVMMC::update_gas_atoms_list()
-{
-  int nlocal = atom->nlocal;
-  int *mask = atom->mask;
-  double **x = atom->x;
-
-  if (atom->nmax > vmmc_nmax) {
-    memory->sfree(local_gas_list);
-    vmmc_nmax = atom->nmax;
-    local_gas_list = (int *) memory->smalloc(vmmc_nmax*sizeof(int),
-     "VMMC:local_gas_list");
-  }
-
-  ngas_local = 0;
-
-  if (region) {
-
-    for (int i = 0; i < nlocal; i++) {
-      if (mask[i] & groupbit) {
-        if (region->match(x[i][0],x[i][1],x[i][2]) == 1) {
-          local_gas_list[ngas_local] = i;
-          ngas_local++;
-        }
-      }
-    }
-
-  } else {
-    for (int i = 0; i < nlocal; i++) {
-      if (mask[i] & groupbit) {
-        local_gas_list[ngas_local] = i;
-        ngas_local++;
-      }
-    }
-  }
-
-  MPI_Allreduce(&ngas_local,&ngas,1,MPI_INT,MPI_SUM,world);
-  MPI_Scan(&ngas_local,&ngas_before,1,MPI_INT,MPI_SUM,world);
-  ngas_before -= ngas_local;
-}
-
-/* ----------------------------------------------------------------------
-  return acceptance ratios
-------------------------------------------------------------------------- */
-
-double FixVMMC::compute_vector(int n)
-{
-  if (n == 0) return ntranslation_attempts;
-  if (n == 1) return ntranslation_successes;
-  return 0.0;
 }
 
 /* ----------------------------------------------------------------------
@@ -1073,8 +556,6 @@ void FixVMMC::write_restart(FILE *fp)
   list[n++] = random_equal->state();
   list[n++] = random_unequal->state();
   list[n++] = ubuf(next_reneighbor).d;
-  list[n++] = ntranslation_attempts;
-  list[n++] = ntranslation_successes;
   list[n++] = ubuf(update->ntimestep).d;
 
   if (comm->me == 0) {
@@ -1100,9 +581,6 @@ void FixVMMC::restart(char *buf)
   random_unequal->reset(seed);
 
   next_reneighbor = (bigint) ubuf(list[n++]).i;
-
-  ntranslation_attempts  = list[n++];
-  ntranslation_successes = list[n++];
 
   bigint ntimestep_restart = (bigint) ubuf(list[n++]).i;
   if (ntimestep_restart != update->ntimestep)

--- a/src/MC/fix_vmmc.h
+++ b/src/MC/fix_vmmc.h
@@ -32,7 +32,6 @@ class FixVMMC : public Fix {
   int setmask() override;
   void init() override;
   void pre_exchange() override;
-  double compute_vector(int) override;
   double memory_usage() override;
   void write_restart(FILE *) override;
   void restart(char *) override;
@@ -42,17 +41,13 @@ class FixVMMC : public Fix {
  private:
   int exclusion_group, exclusion_group_bit;
   int nvmmc_type, nevery, seed;
-  int ncycles, nmcmoves;
+  int ncycles, nvmmcmoves;
   double patomtrans, pmctot;
-  int ngas;                // # of gas atoms on all procs
-  int ngas_local;          // # of gas atoms on this proc
-  int ngas_before;         // # of gas atoms on procs < this proc
   int exchmode;            // exchange ATOM, MOLECULE not supported
   int movemode;            // move ATOM, MOLECULE not supported
   class Region *region;    // vmmc region
   char *idregion;          // vmmc region id
   bool pressure_flag;      // true if user specified reservoir pressure
-  bool full_flag;          // true if doing full system energy calculations
 
   int groupbitall;            // group bitmask for inserted atoms
   int ngroups;                // number of group-ids for inserted atoms
@@ -61,34 +56,23 @@ class FixVMMC : public Fix {
   char **grouptypestrings;    // list of type-based group-ids for inserted atoms
   int *grouptypebits;         // list of type-based group bitmasks
   int *grouptypes;            // list of type-based group types
-  double ntranslation_attempts;
-  double ntranslation_successes;
 
   int mc_active;              // 1 during MC trials, otherwise 0
 
   int vmmc_nmax;
   int max_region_attempts;
-  double gas_mass;
   double reservoir_temperature;
   double tfac_insert;
-  double displace;
-  double max_rotation_angle;
+  double max_translate, max_rotate;
   double beta;
   double volume, pressure;
   double xlo, xhi, ylo, yhi, zlo, zhi;
   double region_xlo, region_xhi, region_ylo, region_yhi, region_zlo, region_zhi;
   double region_volume;
-  double energy_stored;    // full energy of old/current configuration
-  double *sublo, *subhi;
-  int *local_gas_list;
   double **cutsq;
   imageint imagezero;
   double overlap_cutoffsq;    // square distance cutoff for overlap
   int overlap_flag;
-  int max_ngas;
-  int min_ngas;
-
-  double energy_intra;
 
   class Pair *pair;
 
@@ -97,23 +81,11 @@ class FixVMMC : public Fix {
 
   class Atom *model_atom;
 
-  int triclinic;    // 0 = orthog box, 1 = triclinic
-
   class Compute *c_pe;
 
   // private methods
 
   void options(int, char **);
-
-  void attempt_atomic_translation();
-  void attempt_atomic_translation_full();
-
-  double energy(int, int, tagint, double *);
-  double energy_full();
-
-  int pick_random_gas_atom();
-  tagint pick_random_gas_molecule();
-  void update_gas_atoms_list();
 
   // VMMC routines
   double energy_pair_vmmc(unsigned int, const double*, const double*,


### PR DESCRIPTION
This PR prunes the FixVMMC class further and initialises the VMMC object in each call of the pre_exchange() routine. This provides correct synchronisation between the LAMMPS and LibVMMC coordinates.