### PR TITLE
Corrected pair energy calculation, removed hard-coded potential

### DIFF
--- a/src/MC/VMMC.cpp
+++ b/src/MC/VMMC.cpp
@@ -208,18 +208,18 @@ namespace vmmc
         if (callbacks.boundaryCallback == nullptr) callbacks.isCustomBoundary = false;
         else callbacks.isCustomBoundary = true;
 
-        std::cout << "Initialised VMMC";
+//        std::cout << "Initialised VMMC";
 #ifdef ISOTROPIC
-        std::cout << " (isotropic)";
+//        std::cout << " (isotropic)";
 #endif
-        std::cout << ".\nseed\t" << rng.getSeed() << '\n';
+//        std::cout << ".\nseed\t" << rng.getSeed() << '\n';
         // Print version info.
 #ifdef COMMIT
-        std::cout << "commit\t" << COMMIT << '\n';
+//        std::cout << "commit\t" << COMMIT << '\n';
 #endif
         // Print branch info.
 #ifdef BRANCH
-        std::cout << "branch\t" << BRANCH << '\n';
+//        std::cout << "branch\t" << BRANCH << '\n';
 #endif
     }
 

--- a/src/MC/fix_vmmc.cpp
+++ b/src/MC/fix_vmmc.cpp
@@ -442,7 +442,7 @@ void FixVMMC::pre_exchange()
   using namespace std::placeholders;
   vmmc::CallbackFunctions callbacks;
 
-  callbacks.energyCallback = std::bind(&FixVMMC::energy_particle_vmmc, this, _1, _2, _3); 
+//  callbacks.energyCallback = std::bind(&FixVMMC::energy_particle_vmmc, this, _1, _2, _3); 
   callbacks.pairEnergyCallback = std::bind(&FixVMMC::energy_pair_vmmc, this, _1, _2, _3, _4, _5, _6);
   callbacks.interactionsCallback = std::bind(&FixVMMC::interactions_vmmc, this, _1, _2, _3, _4);
   callbacks.postMoveCallback = std::bind(&FixVMMC::post_move_vmmc, this, _1, _2, _3);
@@ -452,21 +452,30 @@ void FixVMMC::pre_exchange()
   double orientations[domain->dimension*atom->natoms];
   bool isIsotropic[atom->natoms];
 
-  for (unsigned int i=0; i<atom->natoms; i++) {
+  int i, ii, inum, id_vmmc;
+  int *ilist;
 
-    coordinates[domain->dimension*i + 0] = atom->x[i][0];
-    coordinates[domain->dimension*i + 1] = atom->x[i][1];
-    coordinates[domain->dimension*i + 2] = atom->x[i][2];
+  inum = list->inum; // number of atoms i for which neighbour lists are held
+  ilist = list->ilist; // local index of atom i
 
-    orientations[domain->dimension*i + 0] = 1.0;
-    orientations[domain->dimension*i + 1] = 0.0;
-    orientations[domain->dimension*i + 2] = 0.0;
+  for (ii=0; ii<inum; ii++) {
 
-    isIsotropic[i] = false;
+    i = ilist[ii]; // assign local index to i
+    id_vmmc = atom->tag[i]-1; // work out libVMMC index
+
+    coordinates[domain->dimension*id_vmmc + 0] = atom->x[i][0];
+    coordinates[domain->dimension*id_vmmc + 1] = atom->x[i][1];
+    coordinates[domain->dimension*id_vmmc + 2] = atom->x[i][2];
+
+    orientations[domain->dimension*id_vmmc + 0] = 1.0;
+    orientations[domain->dimension*id_vmmc + 1] = 0.0;
+    orientations[domain->dimension*id_vmmc + 2] = 0.0;
+
+    isIsotropic[id_vmmc] = true;
 
   }
 
-  unsigned int maxInteractions= 1000; // assuming hcp or fcc packing
+  unsigned int maxInteractions= 1000;
   double boxSize[3];
   boxSize[0] = domain->boxhi[0] - domain->boxlo[0];
   boxSize[1] = domain->boxhi[1] - domain->boxlo[1];
@@ -496,14 +505,16 @@ double FixVMMC::energy_pair_vmmc(
     unsigned int index2, const double* pos2, const double* orient2){   
   
   double pair_e = 0;
-  double sigma = 0.5;
+  double sigma = 1.0;
   double epsilon=2.0;
+  double rc=2.5;
   double rsqrd = 0;
   double r6 = 0;
   double invr6 =0;
   double total_energy = 0.0;
   double sig3 = 0;
-  
+  double shift = pow(1/rc,12)-pow(1/rc,6); 
+ 
   std::vector<double> sep = {0,0,0};
   
   //calculate separation distance
@@ -526,118 +537,16 @@ double FixVMMC::energy_pair_vmmc(
 
     sig3 =sigma*sigma*sigma;
     
-    total_energy += 4*epsilon*((sig3*sig3*sig3*sig3*invr6*invr6)-(sig3*sig3*invr6));
+    total_energy += 4*epsilon*((sig3*sig3*sig3*sig3*invr6*invr6)-(sig3*sig3*invr6)- shift);
 
   }
 
-//  printf("ENERGY PAIR %d %d  %le\n", index1, index2, total_energy);
+//  printf("ENERGY PAIR %d %d  %15.8le  %8.4g %8.4g %8.4g  %8.4g %8.4g %8.4g\n", index1, index2, total_energy, pos1[0],pos1[1],pos1[2],pos2[0],pos2[1],pos2[2]);
 
   return total_energy;
 
 }
 
-/* ----------------------------------------------------------------------
-   compute total pair interaction energy of a particle for VMMC library
-------------------------------------------------------------------------- */
-
-double FixVMMC::energy_particle_vmmc(
-    unsigned int index, const double* pos, const double* orient){
-  int i, j, ii, jj, inum, jnum;
-  int *ilist, *jlist, *numneigh, **firstneigh;
-  
-  //interaction parameters
-  double total_energy = 0;
-  double sigma = 2.5;
-  double epsilon=1.0;
-
-  //interaction parameters 
-
-  inum = list->inum; // number of atoms i for which neighbour lists are held
-  ilist = list->ilist; // local index of atom i
-  numneigh = list->numneigh; // number of neighbours j of atom i
-  firstneigh = list->firstneigh; // pointer to 1st neighbour j of atom i
- 
-  for (ii=0; ii<inum; ii++){
-
-    i = ilist[ii]; // assign local index of i
-    jnum = numneigh[i]; // obtain number of neighbours of i
-    jlist = firstneigh[i]; // obtain pointer to 1st neighbour j
-
-    for(jj=0; jj<jnum; jj++){ // loop over number of neighbours j
-      j = jlist[jj]; // assign logal index of j
-      j &= NEIGHMASK; // ???
-    }
-  }
-  //get correct ids
-  int global_lammps, localIndex, jnumloc, localJ, globaljminus, globalj;
- 
-  global_lammps = index+1;
-
-  localIndex = atom->map(global_lammps);
-
-  jnumloc = numneigh[localIndex];
-  
-  std::vector<double> neighbours;
-
- for (int jj = 0; jj<jnumloc; jj++) {
-    localJ = firstneigh[localIndex][jj];
-    
-    globaljminus = atom->tag[localJ];
-    
-    globalj = globaljminus-1;
-
-    neighbours.push_back(globalj);
-
-  }
-
-  std::vector<double> posIndex = {0,0,0}; //position of partcile with passed in index
-
-  for (int i=0; i<3; i++){
-
-    posIndex[i]=pos[index*3+i]; //get position of index from pos array 
-
-  }
-  
-
-  //main energy cacluation loop
-
-  for (int j =0; j<jnumloc; j++){
-
-    std::vector<double> posj = {0,0,0};
-    std::vector<double> sep = {0,0,0};
-    double sepsqrd = 0;
-    double r6 = 0;
-    double invr6 =0;
-    double sig3 = 0;
-
-    int jindex = neighbours[j];
-
-    for(i=0;i<3;i++){
-      
-      posj[i]=pos[jindex*3+i]; //get j positions
-
-      sep[i]=posj[i]-posIndex[i]; // get separation distance
-
-      sepsqrd += sep[i]*sep[i]; // get separation squared  
-
-    }
-
-    sig3 =sigma*sigma*sigma;
-    
-    
-    r6 = sepsqrd*sepsqrd*sepsqrd;
-    
-    invr6 =1/r6;
-
-    total_energy += 4*epsilon*((sigma*sigma*sigma*sigma*invr6*invr6)-(sigma*sigma*invr6));
-
-  }
-
-
-//  printf("ENERGY PARTICLE %d %le\n",index,total_energy);
-
-  return total_energy;
-}
 
 /* ----------------------------------------------------------------------
    determine all interactions for a given particle for VMMC library
@@ -654,60 +563,27 @@ unsigned int FixVMMC::interactions_vmmc(
   numneigh = list->numneigh; // number of neighbours j of atom i
   firstneigh = list->firstneigh; // pointer to 1st neighbour j of atom i
 
-  //printf("INTERACTIONS index = %d\n", index);
-  for (ii=0; ii<inum; ii++) {
+  i = atom->map(index+1);
+  jnum = numneigh[i];
+  jlist = firstneigh[i];
 
-    i = ilist[ii]; // assign local index of i
-    jnum = numneigh[i]; // obtain number of neighbours of i
-    jlist = firstneigh[i]; // obtain pointer to 1st neighbour j
+  for (jj=0; jj<jnum; jj++) {
 
-    //printf("i = %d  atom->tag[i] = %d  atom->map(atom->tag[i]) = %d  jnum = %d ", i, atom->tag[i], atom->map(atom->tag[i]), jnum); // print global ID of atom i and number of neighbours j
+    j = jlist[jj];
+    j &= NEIGHMASK;
 
-    for (jj=0; jj<jnum; jj++) { // loop over number of neighbours j
-      j = jlist[jj]; // assign logal index of j
-      j &= NEIGHMASK; // ???
-      //printf("j = %d   atom->tag[j] = %d  atom->map(atom->tag[j]) = %d", j, atom->tag[j], atom->map(atom->tag[j])); // print global ID of atom j
-    }
-    //printf("\n");
+    interact[jj]=atom->tag[j]-1; // work out libVMMC index
+
   }
 
-  //get correct ids
- int global_lammps, localIndex, jnumloc, localJ, globaljminus, globalj;
- 
- 
- 
- 
- global_lammps = index+1;
-
- localIndex = atom->map(global_lammps);
- //printf("local i of index %d local i of index", localIndex, index);
-
- jnumloc = numneigh[localIndex];
-
-
- for (int jj = 0; jj<jnumloc; jj++) {
-    localJ = firstneigh[localIndex][jj];
-    globaljminus = atom->tag[localJ];
-    globalj = globaljminus-1;
-    interact[jj]=globalj;
-
-    //printf("\nlocalj ");
-   // printf(" %d ",localJ);
-    //printf(" localj\n");
-    
-    //printf("\nglobalj ");
-   // printf(" %d ",globalj);
-   // printf(" globalj\n");
-
- }
-
-  printf("%d %d  ",index,jnumloc);
-  for (int jj = 0; jj<jnumloc; jj++) {
+/*
+  printf("INDEX %d %d  ",index,jnum);
+  for (int jj = 0; jj<jnum; jj++) {
     printf("%d ",interact[jj]);
   }
   printf("\n");
-
-  return jnumloc;
+*/
+  return jnum;
     
   
 }
@@ -720,9 +596,11 @@ unsigned int FixVMMC::interactions_vmmc(
 void FixVMMC::post_move_vmmc(
     unsigned int index, const double* pos, const double* orient)
 {
-  atom->x[index][0] = pos[0];
-  atom->x[index][1] = pos[1];
-  atom->x[index][2] = pos[2];
+  int i = atom->map(index+1); // work out local index
+
+  atom->x[i][0] = pos[0];
+  atom->x[i][1] = pos[1];
+  atom->x[i][2] = pos[2];
 
   return;
 }

--- a/src/MC/fix_vmmc.cpp
+++ b/src/MC/fix_vmmc.cpp
@@ -504,47 +504,52 @@ double FixVMMC::energy_pair_vmmc(
     unsigned int index1, const double* pos1, const double* orient1,
     unsigned int index2, const double* pos2, const double* orient2){   
   
-  double pair_e = 0;
-  double sigma = 1.0;
-  double epsilon=2.0;
-  double rc=2.5;
-  double rsqrd = 0;
-  double r6 = 0;
-  double invr6 =0;
+  int i;
+  int *type = atom->type;
+  pair = force->pair;
+  cutsq = force->pair->cutsq;
+  double rsq;
+
+  double fpair = 0.0;
+  double factor_coul = 0.0;
+  double factor_lj = 1.0;
+
+  std::vector<double> delr = {0,0,0};
   double total_energy = 0.0;
-  double sig3 = 0;
-  double shift = pow(1/rc,12)-pow(1/rc,6); 
- 
-  std::vector<double> sep = {0,0,0};
-  
+
+  // local indices
+  int i1 = atom->map(index1+1);
+  int i2 = atom->map(index2+1);
+
+  int i1type = type[i1];
+  int i2type = type[i2];
+
   //calculate separation distance
-  for(int i=0; i<3; i++){
-
-    sep[i]=pos2[i]-pos1[i];
-    
-    rsqrd +=sep[i]*sep[i];
-
-  }
-    
-  //check if particles are close enough to interact
-  //if close enough, calculate interaction energy
-
-  if(rsqrd<2.5*2.5){
-
-    r6 = rsqrd*rsqrd*rsqrd;
-    
-    invr6 =1/r6;
-
-    sig3 =sigma*sigma*sigma;
-    
-    total_energy += 4*epsilon*((sig3*sig3*sig3*sig3*invr6*invr6)-(sig3*sig3*invr6)- shift);
-
+  for(i=0; i<3; i++){
+    delr[i]=pos1[i]-pos2[i];
   }
 
-//  printf("ENERGY PAIR %d %d  %15.8le  %8.4g %8.4g %8.4g  %8.4g %8.4g %8.4g\n", index1, index2, total_energy, pos1[0],pos1[1],pos1[2],pos2[0],pos2[1],pos2[2]);
+  //enforce minimum image
+  for (i=0;i<3;i++) {
+    if (delr[i] < -0.5*domain->boxhi[i]) delr[i] += domain->boxhi[i];
+    if (delr[i] >= 0.5*domain->boxhi[i]) delr[i] -= domain->boxhi[i];
+  }
 
+  for(i=0; i<3; i++){
+    rsq +=delr[i]*delr[i];
+  }
+    
+  // calculate pair energy if within cutoff
+  if(rsq < cutsq[i1type][i2type]){
+    total_energy = pair->single(i1,i2,i1type,i2type,rsq,factor_coul,factor_lj,fpair);
+  }
+
+/*
+  printf("ENERGY PAIR %d %d   %d %d   %le\n", index1, index2, i1, i2, total_energy);
+  printf("POS LMP     %8.4g %8.4g %8.4g  %8.4g %8.4g %8.4g\n", x[i1][0],x[i1][1],x[i1][2], x[i2][0],x[i2][1],x[i2][2]);
+  printf("POS VMMC    %8.4g %8.4g %8.4g  %8.4g %8.4g %8.4g\n", pos1[0],pos1[1],pos1[2], pos2[0],pos2[1],pos2[2]);
+*/
   return total_energy;
-
 }
 
 
@@ -584,10 +589,7 @@ unsigned int FixVMMC::interactions_vmmc(
   printf("\n");
 */
   return jnum;
-    
-  
 }
-
 
 /* ----------------------------------------------------------------------
    post move update of atom coordinates and orientations

--- a/src/MC/fix_vmmc.h
+++ b/src/MC/fix_vmmc.h
@@ -74,6 +74,7 @@ class FixVMMC : public Fix {
   double overlap_cutoffsq;    // square distance cutoff for overlap
   int overlap_flag;
 
+  class Pair *pair;
   class RanPark *random_equal;
   class RanPark *random_unequal;
   class NeighList *list;

--- a/src/MC/fix_vmmc.h
+++ b/src/MC/fix_vmmc.h
@@ -83,7 +83,6 @@ class FixVMMC : public Fix {
   // VMMC routines
   double energy_pair_vmmc(unsigned int, const double*, const double*,
                           unsigned int, const double*, const double*);
-  double energy_particle_vmmc(unsigned int, const double*, const double*);
   unsigned int interactions_vmmc(unsigned int, const double*, const double*, unsigned int*);
   void post_move_vmmc(unsigned int, const double*, const double*);
 


### PR DESCRIPTION
This PR implements changes that enforce a minimum image in the calculation of the pair energy. This removes the erroneous blips in the energy when particles interact via the PBC.

The hard-coded version of the LJ potential has been removed and new potential parameters can be now set via the input file. An example is attached to this PR.

The redundant particle energy routine has been removed as it serves only monitoring purposes in libVMMC. It's logic can be implemented with the existing pair energy and interactions routines.

[lj_bench.in.txt](https://github.com/user-attachments/files/21374206/lj_bench.in.txt)